### PR TITLE
Support for defining SC at container level

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,9 @@ In order to use `exec` handler, you can define field `livenessProbe.exec` in you
 
 All notable changes to this project will be documented here
 
+### v1.3.0
+- Feature: Support for adding Security Context at conatiner level in deployment.
+
 ### v1.2.11
 - Feature: Use `policy/v1/PodDisruptionBudget` if supported by the target cluster.
 

--- a/README.md
+++ b/README.md
@@ -33,30 +33,30 @@ To uninstall the chart:
 
 ### Deployment Paramaters
 
-| Name                                  | Description                                                                                                                                | Value           |
-|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------| --------------- |
-| deployment.enabled                    | Enable deployment on helm chart deployments                                                                                                | `true`          |
+| Name                                  | Description                                                                                                                                | Value          |
+|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|----------------|
+| deployment.enabled                    | Enable deployment on helm chart deployments                                                                                                | `true`         |
 | deployment.strategy                   | Strategy for updating deployments                                                                                                          | `RollingUpdate` |
-| deployment.reloadOnChange             | Reload deployment if configMap/secret mounted are updated                                                                                  | `true`          |
-| deployment.nodeSelector               | Select node to deploy this application                                                                                                     | `{}`            |
-| deployment.hostAliases                | Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable | `[]`            |
-| deployment.additionalLabels           | Additional labels for Deployment                                                                                                           | `{}`            |
-| deployment.podLabels                  | Additional label added on pod which is used in Service's Label Selector                                                                    | {}              |
-| deployment.annotations                | Annotations on deployments                                                                                                                 | `{}`            |
-| deployment.additionalPodAnnotations   | Additional Pod Annotations added on pod created by this Deployment                                                                         | `{}`            |
-| deployment.replicas                   | Replicas to be created                                                                                                                     | ``              |
-| deployment.imagePullSecrets           | Secrets used to pull image                                                                                                                 | `""`            |
-| deployment.env                        | Environment variables to be passed to the app container                                                                                    | `{}`            |
-| deployment.volumes                    | Volumes to be added to the pod                                                                                                             | `{}`            |
-| deployment.volumeMounts               | Mount path for Volumes                                                                                                                     | `{}`            |
-| deployment.command                    | Command for primary container of deployment                                                                                                | `[]`            |
-| deployment.args                       | Arg for primary container of deployment                                                                                                    | `[]`            |
-| deployment.tolerations                | Taint tolerations for nodes                                                                                                                | `[]`            |
-| deployment.affinity                   | Affinity for pod/node                                                                                                                      | `[]`            |
-| deployment.ports                      | Ports for primary container                                                                                                                | `[]`            |
-| deployment.securityContext            | Security Context for the pod                                                                                                               | `{}`            |
-| deployment.additionalContainers       | Add additional containers besides init and app containers                                                                                  | `[]             |
-| deployment.containers.securityContext | Add security context at container level                                                                                                    | `[]             |
+| deployment.reloadOnChange             | Reload deployment if configMap/secret mounted are updated                                                                                  | `true`         |
+| deployment.nodeSelector               | Select node to deploy this application                                                                                                     | `{}`           |
+| deployment.hostAliases                | Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable | `[]`           |
+| deployment.additionalLabels           | Additional labels for Deployment                                                                                                           | `{}`           |
+| deployment.podLabels                  | Additional label added on pod which is used in Service's Label Selector                                                                    | {}             |
+| deployment.annotations                | Annotations on deployments                                                                                                                 | `{}`           |
+| deployment.additionalPodAnnotations   | Additional Pod Annotations added on pod created by this Deployment                                                                         | `{}`           |
+| deployment.replicas                   | Replicas to be created                                                                                                                     | ``             |
+| deployment.imagePullSecrets           | Secrets used to pull image                                                                                                                 | `""`           |
+| deployment.env                        | Environment variables to be passed to the app container                                                                                    | `{}`           |
+| deployment.volumes                    | Volumes to be added to the pod                                                                                                             | `{}`           |
+| deployment.volumeMounts               | Mount path for Volumes                                                                                                                     | `{}`           |
+| deployment.command                    | Command for primary container of deployment                                                                                                | `[]`           |
+| deployment.args                       | Arg for primary container of deployment                                                                                                    | `[]`           |
+| deployment.tolerations                | Taint tolerations for nodes                                                                                                                | `[]`           |
+| deployment.affinity                   | Affinity for pod/node                                                                                                                      | `[]`           |
+| deployment.ports                      | Ports for primary container                                                                                                                | `[]`           |
+| deployment.securityContext            | Security Context for the pod                                                                                                               | `{}`           |
+| deployment.additionalContainers       | Add additional containers besides init and app containers                                                                                  | `[]`           |
+| deployment.containers.securityContext | Add security context at container level                                                                                                    | `{}`           |
 
 #### Deployment Resources Parameters
 

--- a/README.md
+++ b/README.md
@@ -33,30 +33,30 @@ To uninstall the chart:
 
 ### Deployment Paramaters
 
-| Name                                  | Description                                                                                                                                | Value          |
-|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|----------------|
-| deployment.enabled                    | Enable deployment on helm chart deployments                                                                                                | `true`         |
-| deployment.strategy                   | Strategy for updating deployments                                                                                                          | `RollingUpdate` |
-| deployment.reloadOnChange             | Reload deployment if configMap/secret mounted are updated                                                                                  | `true`         |
-| deployment.nodeSelector               | Select node to deploy this application                                                                                                     | `{}`           |
-| deployment.hostAliases                | Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable | `[]`           |
-| deployment.additionalLabels           | Additional labels for Deployment                                                                                                           | `{}`           |
-| deployment.podLabels                  | Additional label added on pod which is used in Service's Label Selector                                                                    | {}             |
-| deployment.annotations                | Annotations on deployments                                                                                                                 | `{}`           |
-| deployment.additionalPodAnnotations   | Additional Pod Annotations added on pod created by this Deployment                                                                         | `{}`           |
-| deployment.replicas                   | Replicas to be created                                                                                                                     | ``             |
-| deployment.imagePullSecrets           | Secrets used to pull image                                                                                                                 | `""`           |
-| deployment.env                        | Environment variables to be passed to the app container                                                                                    | `{}`           |
-| deployment.volumes                    | Volumes to be added to the pod                                                                                                             | `{}`           |
-| deployment.volumeMounts               | Mount path for Volumes                                                                                                                     | `{}`           |
-| deployment.command                    | Command for primary container of deployment                                                                                                | `[]`           |
-| deployment.args                       | Arg for primary container of deployment                                                                                                    | `[]`           |
-| deployment.tolerations                | Taint tolerations for nodes                                                                                                                | `[]`           |
-| deployment.affinity                   | Affinity for pod/node                                                                                                                      | `[]`           |
-| deployment.ports                      | Ports for primary container                                                                                                                | `[]`           |
-| deployment.securityContext            | Security Context for the pod                                                                                                               | `{}`           |
-| deployment.additionalContainers       | Add additional containers besides init and app containers                                                                                  | `[]`           |
-| deployment.containers.securityContext | Add security context at container level                                                                                                    | `{}`           |
+| Name                                | Description                                                                                                                                | Value          |
+|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|----------------|
+| deployment.enabled                  | Enable deployment on helm chart deployments                                                                                                | `true`         |
+| deployment.strategy                 | Strategy for updating deployments                                                                                                          | `RollingUpdate` |
+| deployment.reloadOnChange           | Reload deployment if configMap/secret mounted are updated                                                                                  | `true`         |
+| deployment.nodeSelector             | Select node to deploy this application                                                                                                     | `{}`           |
+| deployment.hostAliases              | Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable | `[]`           |
+| deployment.additionalLabels         | Additional labels for Deployment                                                                                                           | `{}`           |
+| deployment.podLabels                | Additional label added on pod which is used in Service's Label Selector                                                                    | {}             |
+| deployment.annotations              | Annotations on deployments                                                                                                                 | `{}`           |
+| deployment.additionalPodAnnotations | Additional Pod Annotations added on pod created by this Deployment                                                                         | `{}`           |
+| deployment.replicas                 | Replicas to be created                                                                                                                     | ``             |
+| deployment.imagePullSecrets         | Secrets used to pull image                                                                                                                 | `""`           |
+| deployment.env                      | Environment variables to be passed to the app container                                                                                    | `{}`           |
+| deployment.volumes                  | Volumes to be added to the pod                                                                                                             | `{}`           |
+| deployment.volumeMounts             | Mount path for Volumes                                                                                                                     | `{}`           |
+| deployment.command                  | Command for primary container of deployment                                                                                                | `[]`           |
+| deployment.args                     | Arg for primary container of deployment                                                                                                    | `[]`           |
+| deployment.tolerations              | Taint tolerations for nodes                                                                                                                | `[]`           |
+| deployment.affinity                 | Affinity for pod/node                                                                                                                      | `[]`           |
+| deployment.ports                    | Ports for primary container                                                                                                                | `[]`           |
+| deployment.securityContext          | Security Context for the pod                                                                                                               | `{}`           |
+| deployment.additionalContainers     | Add additional containers besides init and app containers                                                                                  | `[]`           |
+| deployment.containerSecurityContext | Add security context at container level                                                                                                    | `{}`           |
 
 #### Deployment Resources Parameters
 

--- a/README.md
+++ b/README.md
@@ -33,29 +33,30 @@ To uninstall the chart:
 
 ### Deployment Paramaters
 
-| Name                     | Description                                                                                  | Value           |
-| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
-| deployment.enabled | Enable deployment on helm chart deployments                                                        | `true`          |
-| deployment.strategy | Strategy for updating deployments                                                                 | `RollingUpdate` |
-| deployment.reloadOnChange| Reload deployment if configMap/secret mounted are updated                                    | `true`          |
-| deployment.nodeSelector | Select node to deploy this application                                                        | `{}`            |
-| deployment.hostAliases | Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable                                                                                                                | `[]`            |
-| deployment.additionalLabels | Additional labels for Deployment                                                          | `{}`            |
-| deployment.podLabels | Additional label added on pod which is used in Service's Label Selector                          | {}              |
-| deployment.annotations | Annotations on deployments                                                                     | `{}`            |
-| deployment.additionalPodAnnotations  | Additional Pod Annotations added on pod created by this Deployment                | `{}`            |
-| deployment.replicas | Replicas to be created                                                                            | ``              |
-| deployment.imagePullSecrets | Secrets used to pull image                                                                | `""`            |
-| deployment.env | Environment variables to be passed to the app container                                                | `{}`            |
-| deployment.volumes | Volumes to be added to the pod                                                                     | `{}`            |
-| deployment.volumeMounts | Mount path for Volumes                                                                        | `{}`            |
-| deployment.command | Command for primary container of deployment                                                        | `[]`            |
-| deployment.args | Arg for primary container of deployment                                                               | `[]`            |
-| deployment.tolerations | Taint tolerations for nodes                                                                    | `[]`            |
-| deployment.affinity | Affinity for pod/node                                                                             | `[]`            |
-| deployment.ports | Ports for primary container                                                                          | `[]`            |
-| deployment.securityContext | Security Context for the pod                                                               | `{}`            |
-| deployment.additionalContainers | Add additional containers besides init and app containers                             | `[]             |
+| Name                                  | Description                                                                                                                                | Value           |
+|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------| --------------- |
+| deployment.enabled                    | Enable deployment on helm chart deployments                                                                                                | `true`          |
+| deployment.strategy                   | Strategy for updating deployments                                                                                                          | `RollingUpdate` |
+| deployment.reloadOnChange             | Reload deployment if configMap/secret mounted are updated                                                                                  | `true`          |
+| deployment.nodeSelector               | Select node to deploy this application                                                                                                     | `{}`            |
+| deployment.hostAliases                | Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable | `[]`            |
+| deployment.additionalLabels           | Additional labels for Deployment                                                                                                           | `{}`            |
+| deployment.podLabels                  | Additional label added on pod which is used in Service's Label Selector                                                                    | {}              |
+| deployment.annotations                | Annotations on deployments                                                                                                                 | `{}`            |
+| deployment.additionalPodAnnotations   | Additional Pod Annotations added on pod created by this Deployment                                                                         | `{}`            |
+| deployment.replicas                   | Replicas to be created                                                                                                                     | ``              |
+| deployment.imagePullSecrets           | Secrets used to pull image                                                                                                                 | `""`            |
+| deployment.env                        | Environment variables to be passed to the app container                                                                                    | `{}`            |
+| deployment.volumes                    | Volumes to be added to the pod                                                                                                             | `{}`            |
+| deployment.volumeMounts               | Mount path for Volumes                                                                                                                     | `{}`            |
+| deployment.command                    | Command for primary container of deployment                                                                                                | `[]`            |
+| deployment.args                       | Arg for primary container of deployment                                                                                                    | `[]`            |
+| deployment.tolerations                | Taint tolerations for nodes                                                                                                                | `[]`            |
+| deployment.affinity                   | Affinity for pod/node                                                                                                                      | `[]`            |
+| deployment.ports                      | Ports for primary container                                                                                                                | `[]`            |
+| deployment.securityContext            | Security Context for the pod                                                                                                               | `{}`            |
+| deployment.additionalContainers       | Add additional containers besides init and app containers                                                                                  | `[]             |
+| deployment.containers.securityContext | Add security context at container level                                                                                                    | `[]             |
 
 #### Deployment Resources Parameters
 

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -233,11 +233,13 @@ spec:
           requests:
             memory: {{ .Values.deployment.resources.requests.memory }}
             cpu: {{ .Values.deployment.resources.requests.cpu }}
-        {{- if .Values.deployment.containers }}
-        {{- if .Values.deployment.containers.securityContext }}
+        {{- if .Values.deployment.containerSecurityContext }}
         securityContext:
-{{ toYaml .Values.deployment.containers.securityContext | indent 10 }}
-        {{- end }}
+{{ toYaml .Values.deployment.containerSecurityContext | indent 10 }}
+        {{- else }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         {{- end }}
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 6 }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -233,6 +233,10 @@ spec:
           requests:
             memory: {{ .Values.deployment.resources.requests.memory }}
             cpu: {{ .Values.deployment.resources.requests.cpu }}
+        {{- if .Values.deployment.containers.securityContext }}
+        securityContext:
+{{ toYaml .Values.deployment.containers.securityContext | indent 10 }}
+        {{- end }}
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 6 }}
         {{- end }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -236,10 +236,6 @@ spec:
         {{- if .Values.deployment.containerSecurityContext }}
         securityContext:
 {{ toYaml .Values.deployment.containerSecurityContext | indent 10 }}
-        {{- else }}
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
         {{- end }}
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 6 }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -233,9 +233,11 @@ spec:
           requests:
             memory: {{ .Values.deployment.resources.requests.memory }}
             cpu: {{ .Values.deployment.resources.requests.cpu }}
+        {{- if .Values.deployment.containers }}
         {{- if .Values.deployment.containers.securityContext }}
         securityContext:
 {{ toYaml .Values.deployment.containers.securityContext | indent 10 }}
+        {{- end }}
         {{- end }}
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 6 }}

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -189,6 +189,11 @@ deployment:
     imagePullPolicy: IfNotPresent
     command: ['/bin/sh']
 
+  # Container Level Security Context
+  containers:
+    securityContext:
+  #      readOnlyRootFilesystem: true
+  #      runAsNonRoot: true
   # Security Context for the pod
   securityContext:
     # fsGroup: 2000

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -176,16 +176,17 @@ deployment:
     requests:
       memory: 128Mi
       cpu: 0.1
-  
+
+  # Security Context at Container Level
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+
   openshiftOAuthProxy:
     enabled: true
     port: 8080
     secretName: "openshift-oauth-proxy-tls"
 
-  #  Security Context at Container Level
-    containerSecurityContext:
-      readOnlyRootFilesystem: true
-      runAsNonRoot: true
 
   # Add additional containers besides init and app containers
   additionalContainers:

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -182,6 +182,11 @@ deployment:
     port: 8080
     secretName: "openshift-oauth-proxy-tls"
 
+  #  Security Context at Container Level
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+
   # Add additional containers besides init and app containers
   additionalContainers:
   - name: sidecar-contaner
@@ -189,11 +194,6 @@ deployment:
     imagePullPolicy: IfNotPresent
     command: ['/bin/sh']
 
-  # Container Level Security Context
-  containers:
-    securityContext:
-  #      readOnlyRootFilesystem: true
-  #      runAsNonRoot: true
   # Security Context for the pod
   securityContext:
     # fsGroup: 2000

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -228,8 +228,8 @@ deployment:
   #   command: ['/bin/sh']
 
   # Security Context at Container Level
-  #  containers:
-  #    securityContext:
+  containers:
+    securityContext:
   #      readOnlyRootFilesystem: true
   #      runAsNonRoot: true
 

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -214,6 +214,11 @@ deployment:
     requests:
       memory: 128Mi
       cpu: 0.1
+
+#  Security Context at Container Level
+  containerSecurityContext:
+#        readOnlyRootFilesystem: true
+#        runAsNonRoot: true
   
   openshiftOAuthProxy: 
     enabled: false
@@ -227,11 +232,6 @@ deployment:
   #   imagePullPolicy: IfNotPresent
   #   command: ['/bin/sh']
 
-  # Security Context at Container Level
-  containers:
-    securityContext:
-  #      readOnlyRootFilesystem: true
-  #      runAsNonRoot: true
 
   # Security Context for the pod
 

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -39,6 +39,7 @@ cronJob:
 # Deployment
 ##########################################################
 deployment:
+
   enabled: true
   # By default deploymentStrategy is set to rollingUpdate with maxSurge of 25% and maxUnavailable of 25%
   # You can change type to `Recreate` or can uncomment `rollingUpdate` specification and adjust them to your usage.
@@ -224,9 +225,16 @@ deployment:
   # - name: sidecar-contaner
   #   image: busybox
   #   imagePullPolicy: IfNotPresent
-  #   command: ['/bin/sh']    
+  #   command: ['/bin/sh']
+
+  # Security Context at Container Level
+  #  containers:
+  #    securityContext:
+  #      readOnlyRootFilesystem: true
+  #      runAsNonRoot: true
 
   # Security Context for the pod
+
   securityContext:
     # fsGroup: 2000
   
@@ -271,6 +279,7 @@ persistence:
   storageSize: 8Gi
   volumeMode: ""
   volumeName: ""
+
 
 ##########################################################
 # Service object for servicing pods

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -217,8 +217,8 @@ deployment:
 
 #  Security Context at Container Level
   containerSecurityContext:
-#        readOnlyRootFilesystem: true
-#        runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
   
   openshiftOAuthProxy: 
     enabled: false


### PR DESCRIPTION
Added support for defining Security Context at Container level for deployments.
**Example**:
deployment:
    containerSecurityContext:
          runAsNonRoot: false

**Note: By default runAsNonRoot and readOnlyRootSystem is true.**