### PR TITLE
Disable Deployment Probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 All notable changes to this project will be documented here
 
-### v1.3.1
+### v1.3.2
 - Feature: Disable liveness and readiness probes.
 
 ### v1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 All notable changes to this project will be documented here
 
 ### v1.3.1
+- Feature: Disable liveness and readiness probes.
+
+### v1.3.1
 - Feature: Support for specifiying tcpSocket probe check mechanisms in probes.
 
 ### v1.3.0

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -184,7 +184,7 @@ deployment:
     tcpSocket: {}
 
   readinessProbe:
-  #  enabled: true
+    enabled: false
   #  failureThreshold: 3
   #  periodSeconds: 10
   #  successThreshold: 1
@@ -197,7 +197,7 @@ deployment:
   #  tcpSocket: {}
 
   livenessProbe:
-  #  enabled: true
+    enabled: false
   #  failureThreshold: 3
   #  periodSeconds: 10
   #  successThreshold: 1

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -184,30 +184,30 @@ deployment:
     tcpSocket: {}
 
   readinessProbe:
-    enabled: true
-    failureThreshold: 3
-    periodSeconds: 10
-    successThreshold: 1
-    timeoutSeconds: 1
-    initialDelaySeconds: 10
-    httpGet: 
-      path: '/path'
-      port: 8080
-    exec: {}
-    tcpSocket: {}
+  #  enabled: true
+  #  failureThreshold: 3
+  #  periodSeconds: 10
+  #  successThreshold: 1
+  #  timeoutSeconds: 1
+  #  initialDelaySeconds: 10
+  #  httpGet:
+  #    path: '/path'
+  #    port: 8080
+  #  exec: {}
+  #  tcpSocket: {}
 
   livenessProbe:
-    enabled: true
-    failureThreshold: 3
-    periodSeconds: 10
-    successThreshold: 1
-    timeoutSeconds: 1
-    initialDelaySeconds: 10
-    httpGet: 
-      path: '/path'
-      port: 8080
-    exec: {}
-    tcpSocket: {}
+  #  enabled: true
+  #  failureThreshold: 3
+  #  periodSeconds: 10
+  #  successThreshold: 1
+  #  timeoutSeconds: 1
+  #  initialDelaySeconds: 10
+  #  httpGet: 
+  #    path: '/path'
+  #    port: 8080
+  #  exec: {}
+  #  tcpSocket: {}
 
   # Resources to be defined for pod
   resources: 


### PR DESCRIPTION
Comment Deployment Probes.  liveness probe in default values is overriding liveness probe in values outside because values from default are merged with values from outside causing both tcpSocket and httpGet to be present, chart gives precendence to exec over httpGet over tcpSocket, this is causing the pod to be stuck in a crashback loop because probe will be different for every pod