### PR TITLE
replace invalid characters in appVersion label

### DIFF
--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -12,7 +12,7 @@ app: {{ template "application.name" . }}
 
 {{- define "application.labels.stakater" -}}
 {{ template "application.labels.selector" . }}
-appVersion: "{{ .Values.deployment.image.tag | trunc 63 | trimSuffix "-" -}}"
+appVersion: "{{ regexReplaceAll "[^a-zA-Z0-9_\\.\\-]" .Values.deployment.image.tag "-" | trunc 63 | trimSuffix "-" -}}"
 {{- end -}}
 
 {{- define "application.labels.chart" -}}


### PR DESCRIPTION
Fixes #216

Replaces all invalid (label) characters in `.metadata.labels.appVersion` in case `.deployment.image.tag` is of kind `latest@sha265:something`:

```yaml
$ helm template test application/ --validate --set=deployment.image.tag="latest@sha256:asdasdasasd-testing_weird.imagetäg"
...
# Source: application/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: application
    appVersion: "latest-sha256-asdasdasasd-testing_weird.imaget-g"
```