### PR TITLE
migrate cronjob and hpa to new api versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 All notable changes to this project will be documented here.
 
+### v2.1.7
+- Update: Use newer API versions for HPA and CronJob if available [PR-221](https://github.com/stakater/application/pull/221).
 ### v2.1.2 && v2.1.3
 - Update: Improve enable conditions by adding capabilites, use `_helpers.tpl` properly, Move to common k8s labels and remove other labels [PR-226](https://github.com/stakater/application/pull/226)
 - Feature: Make `ingress` path configurable [PR-226](https://github.com/stakater/application/pull/226)

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -1,6 +1,10 @@
 {{- if (.Values.cronJob).enabled }}
 {{- range $name, $job := .Values.cronJob.jobs }}
+{{ if $.Capabilities.APIVersions.Has "batch/v1/CronJob" -}}
+apiVersion: batch/v1
+{{- else -}}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   labels:

--- a/application/templates/hpa.yaml
+++ b/application/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.autoscaling).enabled .Values.deployment }}
-{{ if $.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" -}}
+{{ if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" -}}
 apiVersion: autoscaling/v2
 {{- else -}}
 apiVersion: autoscaling/v2beta2

--- a/application/templates/hpa.yaml
+++ b/application/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if and (.Values.autoscaling).enabled .Values.deployment }}
+{{ if $.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "application.name" . }}


### PR DESCRIPTION
* Cronjob v1beta1 => v1
* HorizontalPodAutoscaler v2beta2 => v2

see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25