### PR TITLE
fix: Repair ingress multiple paths definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 All notable changes to this project will be documented here.
 
 ### v2.1.4
-
 - Fix: Repair ingress multiple paths definitions [PR-233](https://github.com/stakater/application/pull/233)
 
 ### v2.1.2 && v2.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 All notable changes to this project will be documented here.
 
-### v2.x [unreleased]
+### v2.1.4
 
 - Fix: Repair ingress multiple paths definitions [PR-233](https://github.com/stakater/application/pull/233)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 All notable changes to this project will be documented here.
 
+### v2.x [unreleased]
+
+- Fix: Repair ingress multiple paths definitions [PR-233](https://github.com/stakater/application/pull/233)
+
 ### v2.1.2 && v2.1.3
 - Update: Improve enable conditions by adding capabilites, use `_helpers.tpl` properly, Move to common k8s labels and remove other labels [PR-226](https://github.com/stakater/application/pull/226)
 - Feature: Make `ingress` path configurable [PR-226](https://github.com/stakater/application/pull/226)

--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ Periodic probe of container liveness. Container will be restarted if the probe f
 | Name | Description | Value |
 | ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
 | ingress.enabled | Enable ingress | `false` |
-| ingress.servicePort | Port of the service that serves pod | `8080` |
+| ingress.servicePort | Port of the service that serves pod. | `8080` |
 | ingress.pathType | Each path in an Ingress is required to have a corresponding path type of ingress hosts to validate rules properly | `ImplementationSpecific` |
-| ingress.hosts | Array of FQDN hosts to be served by this ingress | `- chart-example.local` |
-| ingress.additionalLables | Labels for ingress | `{}` |
+| ingress.hosts | Array of hosts to be served by this ingress. See example. | `[]` |
+| ingress.additionalLabels | Labels for ingress | `{}` |
 | ingress.annotations | Annotations for ingress | `{}` |
 | ingress.tls | TLS block for ingress | `[]` |
 | ingress.ingressClassName | Name of the ingress class | '' |

--- a/application/templates/ingress.yaml
+++ b/application/templates/ingress.yaml
@@ -24,8 +24,8 @@ spec:
     {{- range .Values.ingress.hosts }}
     - host: {{ tpl .host $ }}
       http:
-        {{- range .paths }}
         paths:
+        {{- range .paths }}
         - path: {{ .path }}
           pathType: {{ default "ImplementationSpecific" (.pathType) }}
           backend:

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -286,6 +286,10 @@ ingress:
       #  pathType: ''
       #  serviceName: ''
       #  servicePort: ''
+      - path: /subpath
+      #  pathType: ''
+      #  serviceName: ''
+      #  servicePort: ''
     - host: '{{ .Release.Name }}.stakater.com'
       paths:
       - path: /


### PR DESCRIPTION
`paths` key in ingress manifest is misplaced