### PR TITLE
make deployment.image.tag and job.image.tag optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 All notable changes to this project will be documented here.
 
+### v2.2.0
+
+- Fix: make deployment.image.tag and job.image.tag optional [PR-234](https://github.com/stakater/application/pull/234)
+
 ### v2.1.11
 - Feature: Add topologySpreadConstraints [PR-239](https://github.com/stakater/application/pull/239)
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To uninstall the chart:
 | Name                     | Description                                                                                  | Value           |
 | ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
 | deployment.image.repository | Image repository for the application                                                      | `repository/image-name`  |
-| deployment.image.tag | Tag of the application image                                                                     | `v1.0.0`        |
+| deployment.image.tag | Tag of the application image                                                                     | `null`          |
 | deployment.image.digest | Digest of the application image                                                               | ``              |
 | deployment.image.pullPolicy | Pull policy for the application image                                                     | `IfNotPresent`  |
 

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -39,7 +39,9 @@ Common labels
 */}}
 {{- define "application.labels" -}}
 helm.sh/chart: {{ include "application.chart" . }}
+{{- if .Values.deployment.image.tag }}
 app.kubernetes.io/version: {{ include "application.version" . | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ include "application.name" . }}
 {{- end }}

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -11,7 +11,8 @@ Define the name of the chart/application.
 Define the name of the chart/application.
 */}}
 {{- define "application.version" -}}
-{{ regexReplaceAll "[^a-zA-Z0-9_\\.\\-]" .Values.deployment.image.tag "-" | trunc 63 | trimSuffix "-" -}}
+  {{- $version := default "" .Values.deployment.image.tag -}}
+  {{- regexReplaceAll "[^a-zA-Z0-9_\\.\\-]" $version "-" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -39,8 +40,8 @@ Common labels
 */}}
 {{- define "application.labels" -}}
 helm.sh/chart: {{ include "application.chart" . }}
-{{- if .Values.deployment.image.tag }}
-app.kubernetes.io/version: {{ include "application.version" . | quote }}
+{{- with include "application.version" . }}
+app.kubernetes.io/version: {{ quote . }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ include "application.name" . }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -43,17 +43,12 @@ spec:
           {{- end }}
           containers:
           - name: {{ $name }}
-            {{- if $job.image.tag }}
-            {{- if $job.image.digest }}
-            image: "{{ $job.image.repository }}:{{ $job.image.tag }}@{{ $job.image.digest }}"
-            {{- else }}
-            image: "{{ $job.image.repository }}:{{ $job.image.tag }}"
-            {{- end }}
-            {{- else if $job.image.digest }}
-            image: "{{ $job.image.repository }}@{{ $job.image.digest }}"
-            {{- else }}
-            image: "{{ $job.image.repository }}"
-            {{- end }}
+
+            {{- $image := required (print "Undefined image repo for container '" $name "'") $job.image.repository }}
+            {{- with $job.image.tag    }} {{- $image = print $image ":" . }} {{- end }}
+            {{- with $job.image.digest }} {{- $image = print $image "@" . }} {{- end }}
+            image: {{ $image }}
+
             {{- if $job.image.imagePullPolicy }}
             imagePullPolicy: {{ $job.image.imagePullPolicy }}
             {{ end }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -43,10 +43,16 @@ spec:
           {{- end }}
           containers:
           - name: {{ $name }}
+            {{- if $job.image.tag }}
             {{- if $job.image.digest }}
-            image: "{{ $job.image.repository }}@{{ $job.image.digest }}"
-            {{- else if $job.image.tag }}
+            image: "{{ $job.image.repository }}:{{ $job.image.tag }}@{{ $job.image.digest }}"
+            {{- else }}
             image: "{{ $job.image.repository }}:{{ $job.image.tag }}"
+            {{- end }}
+            {{- else if $job.image.digest }}
+            image: "{{ $job.image.repository }}@{{ $job.image.digest }}"
+            {{- else }}
+            image: "{{ $job.image.repository }}"
             {{- end }}
             {{- if $job.image.imagePullPolicy }}
             imagePullPolicy: {{ $job.image.imagePullPolicy }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -130,17 +130,12 @@ spec:
           name: proxy-tls 
         {{- end }}
       - name: {{ template "application.name" . }}
-        {{- if .Values.deployment.image.tag }}
-        {{- if .Values.deployment.image.digest }}
-        image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}@{{ .Values.deployment.image.digest }}"
-        {{- else }}
-        image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
-        {{- end }}
-        {{- else if .Values.deployment.image.digest }}
-        image: "{{ .Values.deployment.image.repository }}@{{ .Values.deployment.image.digest }}"
-        {{- else }}
-        image: "{{ .Values.deployment.image.repository }}"
-        {{- end }}
+
+        {{- $image := required "Undefined image for application container" .Values.deployment.image.repository }}
+        {{- with .Values.deployment.image.tag    }} {{- $image = print $image ":" . }} {{- end }}
+        {{- with .Values.deployment.image.digest }} {{- $image = print $image "@" . }} {{- end }}
+        image: {{ $image }}
+
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         {{- if .Values.deployment.command }}
         command: {{- include "application.tplvalues.render" (dict "value" .Values.deployment.command "context" $) | nindent 12 }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -130,10 +130,16 @@ spec:
           name: proxy-tls 
         {{- end }}
       - name: {{ template "application.name" . }}
+        {{- if .Values.deployment.image.tag }}
         {{- if .Values.deployment.image.digest }}
-        image: "{{ .Values.deployment.image.repository }}@{{ .Values.deployment.image.digest }}"
-        {{- else if .Values.deployment.image.tag }}
+        image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}@{{ .Values.deployment.image.digest }}"
+        {{- else }}
         image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+        {{- end }}
+        {{- else if .Values.deployment.image.digest }}
+        image: "{{ .Values.deployment.image.repository }}@{{ .Values.deployment.image.digest }}"
+        {{- else }}
+        image: "{{ .Values.deployment.image.repository }}"
         {{- end }}
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         {{- if .Values.deployment.command }}

--- a/application/tests/cronjob_test.yaml
+++ b/application/tests/cronjob_test.yaml
@@ -1,0 +1,79 @@
+suite: CronJob
+
+templates:
+  - cronjob.yaml
+
+tests:
+  - it: does not fail rendering when job image tag and digest are absent
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: ""
+              digest: ""
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: example-image
+
+  - it: fails rendering when job image repository is not given
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: ""
+              tag: doesnt
+              digest: matter
+    asserts:
+      - failedTemplate:
+          errorMessage: "Undefined image repo for container 'example'"
+
+  - it: uses tag when defined
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+              digest: ""
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: example-image:example-tag
+
+  - it: uses digest when defined
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: ""
+              digest: sha256:example-digest
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: example-image@sha256:example-digest
+
+  - it: uses both tag and digest when given both
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+              digest: sha256:example-digest
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: example-image:example-tag@sha256:example-digest

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -50,6 +50,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: example-image:example-tag
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: example-tag
 
   - it: uses image digest when given
     set:
@@ -60,6 +63,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: example-image@sha256:example-digest
+      - isNull:
+          path: metadata.labels["app.kubernetes.io/version"]
 
   - it: uses both image digest and tag when given both
     set:

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -23,3 +23,50 @@ tests:
           content:
             image: openshift/oauth-proxy:latest
           any: true
+
+  - it: does not fail to render when image tag and digest are not given
+    set:
+      deployment.image.repository: example-image
+      deployment.image.tag: ""
+      deployment.image.digest: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-image
+
+  - it: fails to render when image repository is not present
+    set:
+      deployment.image.repository: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "Undefined image for application container"
+
+  - it: uses image tag when given
+    set:
+      deployment.image.repository: example-image
+      deployment.image.tag: example-tag
+      deployment.image.digest: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-image:example-tag
+
+  - it: uses image digest when given
+    set:
+      deployment.image.repository: example-image
+      deployment.image.tag: ""
+      deployment.image.digest: sha256:example-digest
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-image@sha256:example-digest
+
+  - it: uses both image digest and tag when given both
+    set:
+      deployment.image.repository: example-image
+      deployment.image.tag: example-tag
+      deployment.image.digest: sha256:example-digest
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-image:example-tag@sha256:example-digest

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -190,7 +190,7 @@ deployment:
   # Image of the app container
   image: 
     repository: repository/image-name
-    tag: v1.0.0
+    tag: null
     digest: '' # if set to a non empty value, digest takes precedence on the tag
     pullPolicy: IfNotPresent
   dnsConfig:

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -190,7 +190,7 @@ deployment:
   # Image of the app container
   image: 
     repository: repository/image-name
-    tag: null
+    tag: ''
     digest: '' # if set to a non empty value, digest takes precedence on the tag
     pullPolicy: IfNotPresent
   dnsConfig:


### PR DESCRIPTION
Hi,

i really like the idea of creating a generic chart which can be used for many use cases, but i have a small issue with the Chart.

Currently you use the the following code block for the image definition:

```
        {{- if .Values.deployment.image.digest }}
        image: "{{ .Values.deployment.image.repository }}@{{ .Values.deployment.image.digest }}"
        {{- else if .Values.deployment.image.tag }}
        image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
        {{- end }}
```

This means that currently `deployment.image.tag` is a required param. The current default value is `v1.0.0`. This is a bit odd, because a image definition is also valid w/o a tag. For example, the following definitions are also valid and not all of them are currently supported by the chart:

```
quay.io/xyz/foo:v3.0.5
quay.io/xyz/baz:latest
quay.io/xyz/bar@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
quay.io/xyz/foo:latest@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
```

Also it's very common that you receive the image as complete "all-in-one" string from a CI/CD pipeline. Extracting just the digest or tag and hand it over to helm could be very frustrating and complex sometimes. So it would be great if you just set the image with the tag and digest as a single parameter. 

Attached you will find a pull request which makes `deployment.image.tag` (and `job.image.tag`) optional and set the default value to `null`.

Let me know what you think about this change.