### PR TITLE
quote app.kubernetes.io/version label

### DIFF
--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -39,7 +39,7 @@ Common labels
 */}}
 {{- define "application.labels" -}}
 helm.sh/chart: {{ include "application.chart" . }}
-app.kubernetes.io/version: {{ include "application.version" . }}
+app.kubernetes.io/version: {{ include "application.version" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ include "application.name" . }}
 {{- end }}


### PR DESCRIPTION
Thanks for updating the chart! I can now use `latest@sha256:asdasd` image tags for all kinds of small opensource projects.

I noticed a regression while trying to deploy [postgres](https://hub.docker.com/_/postgres) with tag: `15.2`, `'15.2'` or `"15.2"`:

```
$ helm template postgresql stakater/application --version=2.1.3 --set deployment.image.tag=15.2 --validate
Error: unable to build kubernetes objects from release manifest: unable to decode "": json: cannot unmarshal number into Go struct field ObjectMeta.metadata.labels of type string
```

The quotation marks always seem to get lost in the parser. The chart renders fine but the kubernetes API refuses "float64" as label value.

The fix produces `app.kubernetes.io/version: "15.2"` in all of the above cases.