### PR TITLE
Manage Release name / selector labels / add label part-of / component

### DIFF
--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -8,6 +8,19 @@ Define the name of the chart/application.
 {{- end -}}
 
 {{/*
+Define a fully qualified app name with Release.Name and chart/application name
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "application.fullname" -}}
+{{- $name := default .Chart.Name .Values.applicationName -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Define the name of the chart/application.
 */}}
 {{- define "application.version" -}}
@@ -39,12 +52,19 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "application.labels" -}}
+app.kubernetes.io/name: {{ include "application.name" . }}
 helm.sh/chart: {{ include "application.chart" . }}
 {{- with include "application.version" . }}
 app.kubernetes.io/version: {{ quote . }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: {{ include "application.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.partOfOverride }}
+app.kubernetes.io/part-of: {{ .Values.partOfOverride }}
+{{- end }}
+{{- if .Values.componentOverride }}
+app.kubernetes.io/component: {{ .Values.componentOverride }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -52,6 +72,7 @@ Selector labels
 */}}
 {{- define "application.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "application.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*

--- a/application/templates/alertmanagerconfig.yaml
+++ b/application/templates/alertmanagerconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}
@@ -13,7 +13,7 @@ spec:
 {{ toYaml .Values.alertmanagerConfig.spec.route | indent 6 }}
 {{- end -}}
 {{- if .Values.alertmanagerConfig.spec.receivers }}
-    receivers: 
+    receivers:
 {{ toYaml .Values.alertmanagerConfig.spec.receivers | indent 6 }}
 {{- end -}}
 {{- if .Values.alertmanagerConfig.spec.inhibitRules }}

--- a/application/templates/certificate.yaml
+++ b/application/templates/certificate.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ template "application.name" . }}-certificate
+  name: {{ template "application.fullname" . }}-certificate
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}
@@ -22,7 +22,7 @@ spec:
   subject:
 {{ include "application.tplvalues.render" ( dict "value" .Values.certificate.subject "context" $ ) | indent 4 }}
   commonName: {{ include "application.tplvalues.render" ( dict "value" .Values.certificate.commonName "context" $ )  }}
- {{- if .Values.certificate.isCA }} 
+ {{- if .Values.certificate.isCA }}
   isCA: {{ .Values.certificate.isCA }}
 {{- end }}
   usages:

--- a/application/templates/configmap.yaml
+++ b/application/templates/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+  name: {{ template "application.fullname" $ }}-{{ $nameSuffix }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
           {{- if $.Values.rbac.serviceAccount.name }}
           serviceAccountName: {{ $.Values.rbac.serviceAccount.name }}
             {{- else }}
-          serviceAccountName: {{ template "application.name" $ }}
+          serviceAccountName: {{ template "application.fullname" $ }}
           {{- end }}
           containers:
           - name: {{ $name }}
@@ -96,7 +96,7 @@ spec:
           restartPolicy: OnFailure
           {{ end }}
           {{- with $job.imagePullSecrets}}
-          imagePullSecrets: 
+          imagePullSecrets:
 {{ toYaml . | indent 12 }}
           {{ end }}
           {{- with $job.volumes }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -13,10 +13,10 @@ metadata:
 {{- if .Values.deployment.annotations }}
 {{ toYaml .Values.deployment.annotations | indent 4 }}
 {{- end }}
-{{- if .Values.deployment.reloadOnChange }} 
+{{- if .Values.deployment.reloadOnChange }}
     reloader.stakater.com/auto: "true"
 {{- end }}
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
 spec:
 {{- if .Values.deployment.replicas }}
@@ -32,7 +32,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "application.selectorLabels" . | indent 8 }}
+{{ include "application.labels" . | indent 8 }}
 {{- if .Values.deployment.podLabels }}
 {{ toYaml .Values.deployment.podLabels | indent 8 }}
 {{- end }}
@@ -52,7 +52,7 @@ spec:
                   "expressionFirstLine": "{{ .Values.deployment.fluentdConfigAnnotations.regexFirstLine }}",
                   "expression": "{{ .Values.deployment.fluentdConfigAnnotations.regex }}",
                   "timeFormat": "{{ .Values.deployment.fluentdConfigAnnotations.timeFormat }}",
-                  "containerName": "{{ template "application.name" . }}"
+                  "containerName": "{{ template "application.fullname" . }}"
                 }
               ]{{- with .Values.deployment.fluentdConfigAnnotations.notifications }},
               "notifications": {
@@ -71,7 +71,7 @@ spec:
 {{- end }}
     spec:
       {{- if .Values.deployment.hostAliases }}
-      hostAliases:      
+      hostAliases:
 {{ toYaml .Values.deployment.hostAliases | indent 6 }}
       {{- end }}
       {{- if .Values.deployment.initContainers }}
@@ -97,7 +97,7 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.deployment.imagePullSecrets }}      
+      {{- if .Values.deployment.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.deployment.imagePullSecrets }}
       {{- end }}
@@ -111,7 +111,7 @@ spec:
         {{- end }}
         - --provider=openshift
         - --upstream=http://localhost:{{ .Values.deployment.openshiftOAuthProxy.port }}
-        - --openshift-service-account={{ template "application.name" . }}
+        - --openshift-service-account={{ template "application.fullname" . }}
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --cookie-secret=SECRET
@@ -127,9 +127,9 @@ spec:
           name: proxy
         volumeMounts:
         - mountPath: /etc/tls/private
-          name: proxy-tls 
+          name: proxy-tls
         {{- end }}
-      - name: {{ template "application.name" . }}
+      - name: {{ template "application.fullname" . }}
 
         {{- $image := required "Undefined image for application container" .Values.deployment.image.repository }}
         {{- with .Values.deployment.image.tag    }} {{- $image = print $image ":" . }} {{- end }}
@@ -155,9 +155,9 @@ spec:
             {{- if .name }}
             name: {{ include "application.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
             {{- else if .nameSuffix }}
-            name: {{ template "application.name" $ }}-{{ include "application.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+            name: {{ template "application.fullname" $ }}-{{ include "application.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
             {{- else }}
-            name: {{ template "application.name" $ }}
+            name: {{ template "application.fullname" $ }}
             {{- end }}
         {{- end }}
         {{- if (eq .type "secret") }}
@@ -165,9 +165,9 @@ spec:
             {{- if .name }}
             name: {{ include "application.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
             {{- else if .nameSuffix }}
-            name: {{ template "application.name" $ }}-{{ include "application.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+            name: {{ template "application.fullname" $ }}-{{ include "application.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
             {{- else }}
-            name: {{ template "application.name" $ }}
+            name: {{ template "application.fullname" $ }}
             {{- end }}
         {{- end }}
         {{- end }}
@@ -197,7 +197,7 @@ spec:
             {{- toYaml .Values.deployment.startupProbe.tcpSocket | nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.deployment.livenessProbe.enabled }} 
+        {{- if .Values.deployment.livenessProbe.enabled }}
         livenessProbe:
           failureThreshold: {{ .Values.deployment.livenessProbe.failureThreshold }}
           periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
@@ -215,7 +215,7 @@ spec:
             {{- toYaml .Values.deployment.livenessProbe.tcpSocket | nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.deployment.readinessProbe.enabled }} 
+        {{- if .Values.deployment.readinessProbe.enabled }}
         readinessProbe:
           failureThreshold: {{ .Values.deployment.readinessProbe.failureThreshold }}
           periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
@@ -233,11 +233,11 @@ spec:
             {{- toYaml .Values.deployment.readinessProbe.tcpSocket | nindent 12 }}
           {{- end }}
         {{- end }}
-      {{- if or (.Values.deployment.volumeMounts) (and (eq .Values.persistence.enabled true) (eq .Values.persistence.mountPVC true) )}} 
+      {{- if or (.Values.deployment.volumeMounts) (and (eq .Values.persistence.enabled true) (eq .Values.persistence.mountPVC true) )}}
         volumeMounts:
         {{- if (eq .Values.persistence.mountPVC true) }}
         - mountPath: {{ .Values.persistence.mountPath }}
-          name: {{ template "application.name" . }}-data
+          name: {{ template "application.fullname" . }}-data
         {{- end }}
         {{- if .Values.deployment.volumeMounts }}
         {{- range $key, $value := .Values.deployment.volumeMounts }}
@@ -261,14 +261,14 @@ spec:
 {{ toYaml .Values.deployment.additionalContainers | indent 6 }}
         {{- end }}
         {{- if .Values.deployment.securityContext }}
-      securityContext:      
+      securityContext:
 {{ toYaml .Values.deployment.securityContext | indent 8 }}
           {{- end }}
       {{- if .Values.deployment.dnsConfig }}
-      dnsConfig:      
+      dnsConfig:
 {{ toYaml .Values.deployment.dnsConfig | indent 8 }}
           {{- end }}
-      {{- if or (.Values.deployment.openshiftOAuthProxy.enabled) (.Values.deployment.volumes) (and (eq .Values.persistence.enabled true) (eq .Values.persistence.mountPVC true) )}} 
+      {{- if or (.Values.deployment.openshiftOAuthProxy.enabled) (.Values.deployment.volumes) (and (eq .Values.persistence.enabled true) (eq .Values.persistence.mountPVC true) )}}
       volumes:
         {{- if .Values.deployment.openshiftOAuthProxy.enabled }}
       - name: proxy-tls
@@ -276,12 +276,12 @@ spec:
           secretName: {{ .Values.deployment.openshiftOAuthProxy.secretName }}
         {{- end }}
         {{- if (eq .Values.persistence.mountPVC true) }}
-      - name: {{ template "application.name" . }}-data
+      - name: {{ template "application.fullname" . }}-data
         persistentVolumeClaim:
           {{- if .Values.persistence.name }}
           claimName: {{ .Values.persistence.name }}
           {{- else }}
-          claimName: {{ template "application.name" . }}-data
+          claimName: {{ template "application.fullname" . }}-data
           {{- end }}
         {{- end }}
         {{- if .Values.deployment.volumes }}
@@ -294,6 +294,6 @@ spec:
       {{- if .Values.rbac.serviceAccount.name }}
       serviceAccountName: {{ .Values.rbac.serviceAccount.name }}
         {{- else }}
-      serviceAccountName: {{ template "application.name" . }}
+      serviceAccountName: {{ template "application.fullname" . }}
       {{- end }}
 {{- end }}

--- a/application/templates/endpointmonitor.yaml
+++ b/application/templates/endpointmonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: endpointmonitor.stakater.com/v1alpha1
 kind: EndpointMonitor
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}
@@ -18,11 +18,11 @@ spec:
   urlFrom:
 {{- if and .Values.route .Values.route.enabled }}
     routeRef:
-      name:  {{ template "application.name" . }}
+      name:  {{ template "application.fullname" . }}
 {{- end }}
 {{- if and .Values.ingress .Values.ingress.enabled }}
     ingressRef:
-      name:  {{ template "application.name" . }}
+      name:  {{ template "application.fullname" . }}
 {{- end }}
 {{- if .Values.endpointMonitor.additionalConfig }}
 {{ toYaml .Values.endpointMonitor.additionalConfig | indent 2 }}

--- a/application/templates/externalsecrets.yaml
+++ b/application/templates/externalsecrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+  name: {{ template "application.fullname" $ }}-{{ $nameSuffix }}
   namespace: {{ include "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}
@@ -34,17 +34,17 @@ spec:
     kind: {{ $.Values.externalSecret.secretStore.kind | default "SecretStore" }}
   {{- end}}
   target:
-    name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+    name: {{ template "application.fullname" $ }}-{{ $nameSuffix }}
     template:
       type: {{ $data.type | default "Opaque" }}
 {{- if or $data.annotations $data.labels}}
       metadata:
 {{- if $data.annotations }}
-        annotations: 
+        annotations:
 {{ toYaml $data.annotations | indent 10 }}
 {{- end }}
 {{- if $data.labels }}
-        labels: 
+        labels:
 {{ toYaml $data.labels | indent 10 }}
 {{- end }}
 {{- end }}

--- a/application/templates/forecastle.yaml
+++ b/application/templates/forecastle.yaml
@@ -2,7 +2,7 @@
 apiVersion: forecastle.stakater.com/v1alpha1
 kind: ForecastleApp
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}
@@ -16,10 +16,10 @@ spec:
   urlFrom:
   {{- if .Values.ingress.enabled }}
     ingressRef:
-      name: {{ template "application.name" . }}
+      name: {{ template "application.fullname" . }}
   {{- else }}
     routeRef:
-      name: {{ template "application.name" . }}
+      name: {{ template "application.fullname" . }}
   {{- end }}
   networkRestricted: {{ .Values.forecastle.networkRestricted }}
   {{- if .Values.forecastle.properties }}

--- a/application/templates/grafanadashboard.yaml
+++ b/application/templates/grafanadashboard.yaml
@@ -6,19 +6,19 @@ metadata:
   name: {{ $name }}
   namespace: {{ template "application.namespace" $ }}
   labels:
-    # this label is used as dashboard selector by grafana operator 
+    # this label is used as dashboard selector by grafana operator
     grafanaDashboard: grafana-operator
   {{- include "application.labels" $ | nindent 4 }}
 {{- if $.Values.grafanaDashboard.additionalLabels }}
 {{ toYaml $.Values.grafanaDashboard.additionalLabels | indent 4 }}
 {{- end }}
 {{- if $.Values.grafanaDashboard.annotations }}
-  annotations: 
+  annotations:
 {{ toYaml $.Values.grafanaDashboard.annotations | indent 4 }}
 {{- end }}
 spec:
   {{- if $content.json }}
-  json: 
+  json:
     {{ $content.json | toJson }}
   {{- end }}
   {{- if $content.url }}

--- a/application/templates/hpa.yaml
+++ b/application/templates/hpa.yaml
@@ -8,7 +8,7 @@ apiVersion: autoscaling/v2beta2
 
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
     {{- include "application.labels" . | nindent 4 }}
@@ -23,7 +23,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "application.name" . }}
+    name: {{ template "application.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/application/templates/ingress.yaml
+++ b/application/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if (.Values.ingress).enabled -}}
 {{- $servicePort := .Values.ingress.servicePort -}}
 {{- $pathType := .Values.ingress.pathType -}}
-{{- $applicationNameTpl := include "application.name" . -}}
+{{- $applicationNameTpl := include "application.fullname" . -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}

--- a/application/templates/networkpolicy.yaml
+++ b/application/templates/networkpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: "networking.k8s.io/v1"
 kind: NetworkPolicy
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}

--- a/application/templates/pdb.yaml
+++ b/application/templates/pdb.yaml
@@ -10,7 +10,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     {{- include "application.labels" . | nindent 4 }}
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
 spec:
   {{- if .Values.pdb.minAvailable }}

--- a/application/templates/prometheusrule.yaml
+++ b/application/templates/prometheusrule.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}

--- a/application/templates/pvc.yaml
+++ b/application/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 {{- if .Values.persistence.name }}
   name: "{{ .Values.persistence.name }}"
 {{- else }}
-  name: {{ template "application.name" . }}-data
+  name: {{ template "application.fullname" . }}-data
 {{- end }}
   namespace: {{ include "application.namespace" . }}
   labels:
@@ -30,10 +30,10 @@ spec:
   storageClassName: "{{ .Values.persistence.storageClass }}"
 {{- end }}
 {{- end }}
-{{- if .Values.persistence.volumeMode }}  
+{{- if .Values.persistence.volumeMode }}
   volumeMode: "{{ .Values.persistence.volumeMode }}"
 {{- end }}
-{{- if .Values.persistence.volumeName }}  
+{{- if .Values.persistence.volumeName }}
   volumeName: "{{ .Values.persistence.volumeName }}"
 {{- end }}
 {{- end }}

--- a/application/templates/role.yaml
+++ b/application/templates/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "application.name" $ }}-role-{{ .name }}
+  name: {{ template "application.fullname" $ }}-role-{{ .name }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/rolebinding.yaml
+++ b/application/templates/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "application.name" $ }}-rolebinding-{{ .name }}
+  name: {{ template "application.fullname" $ }}-rolebinding-{{ .name }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}
@@ -17,13 +17,13 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "application.name" $ }}-role-{{ .name }}
+  name: {{ template "application.fullname" $ }}-role-{{ .name }}
 subjects:
   - kind: ServiceAccount
   {{- if $.Values.rbac.serviceAccount.name }}
     name: {{ $.Values.rbac.serviceAccount.name }}
   {{- else }}
-    name: {{ template "application.name" $ }}
+    name: {{ template "application.fullname" $ }}
   {{- end }}
     namespace: {{ $.Release.Namespace }}
 ---

--- a/application/templates/route.yaml
+++ b/application/templates/route.yaml
@@ -2,7 +2,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}
@@ -28,7 +28,7 @@ spec:
     {{- end }}
   to:
     kind: Service
-    name: {{ template "application.name" . }}
+    name: {{ template "application.fullname" . }}
     {{- if .Values.route.to }}
     weight: {{ .Values.route.to.weight }}
     {{- else }}

--- a/application/templates/sealedsecrets.yaml
+++ b/application/templates/sealedsecrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+  name: {{ template "application.fullname" $ }}-{{ $nameSuffix }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}
@@ -15,10 +15,10 @@ metadata:
 {{- end }}
 {{- if or ($.Values.sealedSecret.annotations) ($config.annotations) ($config.clusterWide) }}
   annotations:
-{{- if $config.annotations }}  
+{{- if $config.annotations }}
 {{ toYaml $config.annotations | indent 4 }}
 {{- end }}
-{{- if $.Values.sealedSecret.annotations }}  
+{{- if $.Values.sealedSecret.annotations }}
 {{ toYaml $.Values.sealedSecret.annotations | indent 4 }}
 {{- end }}
 {{- if $config.clusterWide}}
@@ -33,21 +33,21 @@ spec:
   template:
     type: {{ $config.type | default "Opaque" }}
     metadata:
-      name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+      name: {{ template "application.fullname" $ }}-{{ $nameSuffix }}
       namespace: {{ template "application.namespace" $ }}
       {{- if or ($.Values.sealedSecret.annotations) ($config.annotations) ($config.clusterWide) }}
       annotations:
-      {{- if $config.annotations }}  
+      {{- if $config.annotations }}
       {{ toYaml $config.annotations | indent 2 }}
       {{- end }}
-      {{- if $.Values.sealedSecret.annotations }}  
+      {{- if $.Values.sealedSecret.annotations }}
       {{ toYaml $.Values.sealedSecret.annotations | indent 2 }}
       {{- end }}
       {{- if $config.clusterWide}}
         sealedsecrets.bitnami.com/cluster-wide: "true"
       {{- end}}
       {{- end }}
-      {{- if or ($config.labels) ($.Values.sealedSecret.additionalLabels) }}  
+      {{- if or ($config.labels) ($.Values.sealedSecret.additionalLabels) }}
       labels:
       {{- if $config.labels }}
       {{ toYaml $config.labels | indent 2 }}

--- a/application/templates/secret.yaml
+++ b/application/templates/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+  name: {{ template "application.fullname" $ }}-{{ $nameSuffix }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/secretproviderclass.yaml
+++ b/application/templates/secretproviderclass.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.secretProviderClass.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "application.labels" $ | nindent 4 }}  
+  {{- include "application.labels" $ | nindent 4 }}
 spec:
   provider: {{ .Values.secretProviderClass.provider }}
   parameters:
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.secretProviderClass.secretObjects }}
   secretObjects:
   {{- range $value := .Values.secretProviderClass.secretObjects }}
-    - data: {{- toYaml $value.data | nindent 8 }}  
+    - data: {{- toYaml $value.data | nindent 8 }}
       secretName: {{ $value.secretName }}
       type: {{ $value.type }}
   {{- end }}

--- a/application/templates/service.yaml
+++ b/application/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "application.name" . }}
+  name: {{ template "application.fullname" . }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" . | nindent 4 }}
@@ -14,7 +14,7 @@ metadata:
 {{ include "application.tplvalues.render" ( dict "value" .Values.service.annotations  "context" $ ) | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.service.type }}  
+{{- if .Values.service.type }}
   type: "{{ .Values.service.type }}"
 {{- end }}
   selector:

--- a/application/templates/serviceaccount.yaml
+++ b/application/templates/serviceaccount.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: OAuthRedirectReference
 reference:
   kind: Route
-  name: {{ include "application.name" . }}
+  name: {{ include "application.fullname" . }}
 {{- end }}
 
 {{- if and .Values.rbac.enabled .Values.rbac.serviceAccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default (include "application.name" .) .Values.rbac.serviceAccount.name }}
+  name: {{ default (include "application.fullname" .) .Values.rbac.serviceAccount.name }}
   namespace: {{ template "application.namespace" . }}
   labels:
     {{- include "application.labels" . | nindent 4 }}

--- a/application/templates/servicemonitor.yaml
+++ b/application/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: "monitoring.coreos.com/v1"
 kind: ServiceMonitor
 metadata:
-  name: {{ template "application.name" . }}-svc-monitor
+  name: {{ template "application.fullname" . }}-svc-monitor
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" . | nindent 4 }}
@@ -18,7 +18,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "application.name" . }}
+{{ include "application.selectorLabels" . | indent 6 }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -19,11 +19,11 @@ deployment:
     rollingUpdate:
       maxSurge: 25%
       maxUnavailable: 25%
-  
+
   # Reload deployment if configMap/secret updates
   reloadOnChange: true
 
-  # Select nodes to deploy which matches the following labels  
+  # Select nodes to deploy which matches the following labels
   nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
 
@@ -48,7 +48,7 @@ deployment:
   # Additional labels for Deployment
   additionalLabels:
     key: value
-  
+
   # Additional label added on pod which is used in Service's Label Selector
   podLabels:
     env: prod
@@ -59,7 +59,7 @@ deployment:
   # Additional Pod Annotations added on pod created by this Deployment
   additionalPodAnnotations:
     key: value
-  
+
   # Annotations for fluentd Configurations
   fluentdConfigAnnotations:
     fluentd:
@@ -88,7 +88,7 @@ deployment:
   env:
     ENVIRONMENT:
        value: "dev"
-  
+
   # Volumes to be added to the pod
   volumes:
     config-volume:
@@ -96,7 +96,7 @@ deployment:
         name: configmap-name
     configmap-volume:
       configMap:
-        name: '{{ template "application.name" . }}-configmap-nameSuffix'
+        name: '{{ template "application.fullname" . }}-configmap-nameSuffix'
     secret-volume:
       secret:
         secretName: secret-name
@@ -106,9 +106,9 @@ deployment:
       persistentVolumeClaim:
         claimName: claim-name
 
-  # Mount path for Volumes 
+  # Mount path for Volumes
   volumeMounts:
-      volume-name: 
+      volume-name:
          mountPath: /path1
 
   # Taint tolerations for nodes
@@ -152,7 +152,7 @@ deployment:
     successThreshold: 1
     timeoutSeconds: 1
     initialDelaySeconds: 10
-    exec: 
+    exec:
       command:
         - cat
         - tmp/healthy
@@ -198,7 +198,7 @@ deployment:
   # Security Context for the pod
   securityContext:
     # fsGroup: 2000
-  
+
   # Command for primary container
   command: []
 
@@ -251,12 +251,12 @@ service:
     config.xposer.stakater.com/IngressURLPath: /
     config.xposer.stakater.com/IngressURLTemplate: '{{ "{{.Service}}.{{.Namespace}}.{{.Domain}}" }}'
     service.alpha.openshift.io/serving-cert-secret-name: |
-      '{{ template "application.name" . }}-tls'
+      '{{ template "application.fullname" . }}-tls'
     xposer.stakater.com/annotations: |-
       kubernetes.io/ingress.class: external-ingress
       ingress.kubernetes.io/rewrite-target: /
       ingress.kubernetes.io/force-ssl-redirect: "true"
-  
+
   ports:
     - port: 8080
       name: http
@@ -273,16 +273,16 @@ ingress:
 
   # Port of the service that serves pods
   servicePort: http
-  
+
   #Set pathType: default is ImplementationSpecific; Options: Exact, Prefix
-  pathType: ImplementationSpecific 
+  pathType: ImplementationSpecific
 
   # List of host addresses to be exposed by this Ingress
 
   hosts:
     - host: chart-example-1.local
     - host: chart-example-2.local
-      paths: 
+      paths:
       - path: /
       #  pathType: ''
       #  serviceName: ''
@@ -322,11 +322,11 @@ route:
     kubernetes.io/ingress.class: external-ingress
     ingress.kubernetes.io/rewrite-target: /
     ingress.kubernetes.io/force-ssl-redirect: "true"
-  
+
   # Additional labels for this Route
   additionalLabels:
     key: value
-  
+
   # If no host is added then openshift inserts the default hostname. To Add host explicitly, use host attribute
   host:
 
@@ -360,7 +360,7 @@ secretProviderClass:
   objects: |
     - objectName: "MONGO_HOST"
       secretPath: "testing/data/mongoDb"
-      secretKey: "MONGO_HOST"  
+      secretKey: "MONGO_HOST"
   secretObjects:
     - data:
       - key: MONGO_HOST
@@ -376,19 +376,19 @@ forecastle:
   # Add additional labels on Forecastle Custom Resource
   additionalLabels:
     key: value
-  
+
   # URL of the icon for the custom app
   icon: https://raw.githubusercontent.com/stakater/ForecastleIcons/master/stakater-big.png
-  
+
   # Name of the application to be displayed on the Forecastle Dashboard
   displayName: "application"
-  
+
   # Group for the custom app (default: .Release.Namespace)
   group: ""
 
   # Add properties to Custom Resource
   properties:
-  
+
   # Whether app is network restricted or not
   networkRestricted: false
 
@@ -404,8 +404,8 @@ rbac:
     # Additional Labels on service account
     additionalLabels:
       key: value
-    
-    # Annotations on service account 
+
+    # Annotations on service account
     annotations:
       # key: value
 
@@ -428,7 +428,7 @@ rbac:
       verbs:
       - get
 
-# Additional ConfigMaps  
+# Additional ConfigMaps
 configMap:
   enabled: true
   additionalLabels:
@@ -482,7 +482,7 @@ secret:
 # Service Monitor to collect Prometheus metrices
 serviceMonitor:
   enabled: true
-  
+
   # Additional labels
   additionalLabels:
     key: value
@@ -529,7 +529,7 @@ autoscaling:
 # EndpointMonitor for IMC (https://github.com/stakater/IngressMonitorController)
 endpointMonitor:
   enabled: true
-  
+
   # Additional labels
   additionalLabels:
     key: value
@@ -541,7 +541,7 @@ endpointMonitor:
 # Certficate CRD to generate the certificate
 certificate:
   enabled: false
-  
+
   # Additional labels
   additionalLabels:
     key: value
@@ -602,7 +602,7 @@ certificate:
 # AlertmanagerConfig object for defining application specific alertmanager configurations
 alertmanagerConfig:
   enabled: true
-  
+
   # AlertmanagerConfig selectionLabels to specify label to be picked up by Alertmanager to add it to base config. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html] under .spec.alertmanagerConfigSelector
   selectionLabels:
     alertmanagerConfig: "workload"
@@ -636,7 +636,7 @@ alertmanagerConfig:
 # PrometheusRule object for defining application alerting rules
 prometheusRule:
   enabled: true
-  
+
   # PrometheusRule labels
   additionalLabels:
     prometheus: stakater-workload-monitoring
@@ -663,13 +663,13 @@ externalSecret:
   #SecretStore defines which SecretStore to use when fetching the secret data
   secretStore:
     name: example-secret-store
-    #kind: SecretStore # or ClusterSecretStore  
+    #kind: SecretStore # or ClusterSecretStore
 
   # RefreshInterval is the amount of time before the values reading again from the SecretStore provider
   refreshInterval: "1m"
   files:
     secret-1-name:
-      #Data defines the connection between the Kubernetes Secret keys and the Provider data 
+      #Data defines the connection between the Kubernetes Secret keys and the Provider data
       data:
         example-secret-key:
           remoteRef:
@@ -689,7 +689,7 @@ externalSecret:
 ##########################################################
 # Network Policy
 ##########################################################
-networkPolicy: 
+networkPolicy:
   enabled: false
   # Additional labels
   additionalLabels:
@@ -698,7 +698,7 @@ networkPolicy:
   # Additional annotations
   annotations:
     # key: value
-  
+
   # Ingress rules
   ingress:
   - from:
@@ -715,7 +715,7 @@ networkPolicy:
     ports:
     - protocol: TCP
       port: 6379
-      
+
   # Egress rules
   egress:
     - to:
@@ -1237,22 +1237,22 @@ grafanaDashboard:
         }
 
 
-cronJob: 
+cronJob:
   enabled: true
   jobs:
     db-migration:
       schedule: "* * * 8 *"
       imagePullSecrets:
        - name: nexus-secret
-      image: 
+      image:
         repository: docker.io/nginx
         tag: v1.0.0
-      env: 
+      env:
         KEY:
           value: VALUE
       command: ["/bin/bash"]
       args: ["-c","sleep 5000"]
-      resources:  
+      resources:
         requests:
             memory: 5Gi
             cpu: 1

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -14,31 +14,31 @@ applicationName: "application"
 
 ##########################################################
 # Global labels
-# These labels will be added on all resources, 
-# and you can add additional labels from below 
+# These labels will be added on all resources,
+# and you can add additional labels from below
 # on individual resource
 ##########################################################
-  
-cronJob: 
+
+cronJob:
   enabled: false
   jobs:
     # db-migration:
     #   schedule: "* * * 8 *"
-    #   env: 
+    #   env:
     #     KEY:
     #       value: VALUE
-    #   image: 
+    #   image:
     #     repository: docker.io/nginx
     #     tag: v1.0.0
     #     digest: '' # if set to a non empty value, digest takes precedence on the tag
     #     imagePullPolicy: IfNotPresent
     #   command: ["/bin/bash"]
     #   args: ["-c","sleep 5000"]
-    #   resources:  
+    #   resources:
     #     requests:
     #         memory: 5Gi
     #         cpu: 1
-  
+
 ##########################################################
 # Deployment
 ##########################################################
@@ -52,13 +52,13 @@ deployment:
     # rollingUpdate:
     #   maxSurge: 25%
     #   maxUnavailable: 25%
-  
+
   # Reload deployment if configMap/secret updates
   reloadOnChange: true
 
-  # Select nodes to deploy which matches the following labels  
+  # Select nodes to deploy which matches the following labels
   nodeSelector:
-    # cloud.google.com/gke-nodepool: default-pool  
+    # cloud.google.com/gke-nodepool: default-pool
 
   # Init containers which runs before the app container
   hostAliases:
@@ -81,9 +81,9 @@ deployment:
   # Additional labels for Deployment
   additionalLabels:
     # key: value
-  
+
   # Additional label added on pod which is used in Service's Label Selector
-  podLabels: 
+  podLabels:
     # env: prod
 
   # Annotations on deployments
@@ -92,7 +92,7 @@ deployment:
   # Additional Pod Annotations added on pod created by this Deployment
   additionalPodAnnotations:
     # key: value
-  
+
   # Annotations for fluentd Configurations
   fluentdConfigAnnotations:
     # fluentd:
@@ -100,7 +100,7 @@ deployment:
     #   timeFormat: world
 
   # Replicas to be created
-  replicas: 
+  replicas:
 
   # Secrets used to pull image
   imagePullSecrets: ""
@@ -126,12 +126,12 @@ deployment:
 #          configMapKeyRef:
 #             name: config
 #             key: frequency
-  
+
   # Volumes to be added to the pod
   volumes:
 #     configmap-volume:
 #       configMap:
-#         name: '{{ template "application.name" . }}-configmap-nameSuffix'
+#         name: '{{ template "application.fullname" . }}-configmap-nameSuffix'
 #     secret-volume:
 #       secret:
 #         secretName: secret-name
@@ -139,7 +139,7 @@ deployment:
 #       persistentVolumeClaim:
 #         claimName: claim-name
 
-  # Mount path for Volumes 
+  # Mount path for Volumes
   volumeMounts:
     # volume-name:
     #    mountPath: path
@@ -188,7 +188,7 @@ deployment:
     #       - ssd
 
   # Image of the app container
-  image: 
+  image:
     repository: repository/image-name
     tag: ''
     digest: '' # if set to a non empty value, digest takes precedence on the tag
@@ -244,8 +244,8 @@ deployment:
   containerSecurityContext:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
-  
-  openshiftOAuthProxy: 
+
+  openshiftOAuthProxy:
     enabled: false
     port: 8080   # Port on which application is running inside container
     secretName: "openshift-oauth-proxy-tls"
@@ -263,7 +263,7 @@ deployment:
 
   securityContext:
     # fsGroup: 2000
-  
+
   # Command for primary container
   command: []
 
@@ -321,12 +321,12 @@ service:
 #     config.xposer.stakater.com/IngressURLPath: /
 #     config.xposer.stakater.com/IngressURLTemplate: '{{ "{{.Service}}.{{.Namespace}}.{{.Domain}}" }}'
 #     service.alpha.openshift.io/serving-cert-secret-name: |
-#       '{{ template "application.name" . }}-tls'
+#       '{{ template "application.fullname" . }}-tls'
 #     xposer.stakater.com/annotations: |-
 #       kubernetes.io/ingress.class: external-ingress
 #       ingress.kubernetes.io/rewrite-target: /
 #       ingress.kubernetes.io/force-ssl-redirect: true
-  
+
   ports:
     - port: 8080
       name: http
@@ -339,7 +339,7 @@ service:
 ##########################################################
 ingress:
   enabled: false
-  
+
   # Name of the ingress class
   ingressClassName: ''
 
@@ -347,12 +347,12 @@ ingress:
   servicePort: http
 
   #Set pathType: default is ImplementationSpecific; Options: Exact, Prefix
-  pathType: ImplementationSpecific 
-  
+  pathType: ImplementationSpecific
+
   # List of host addresses to be exposed by this Ingress
   hosts:
     - host: chart-example.local
-      # paths: 
+      # paths:
       # - path: /
       #  pathType: ''
       #  serviceName: ''
@@ -384,14 +384,14 @@ route:
     # kubernetes.io/ingress.class: external-ingress
     # ingress.kubernetes.io/rewrite-target: /
     # ingress.kubernetes.io/force-ssl-redirect: true
-  
+
   # Additional labels for this Route
   additionalLabels:
-  
+
   # If no host is added then openshift inserts the default hostname. To Add host explicitly, use host attribute
   host:
-  
-  path: 
+
+  path:
   # Port of the service that serves pods
   port:
     targetPort: http
@@ -424,17 +424,17 @@ secretProviderClass:
   # vaultAddress: http://vault:8200
   roleName: ""
   # roleName: example-role
-  objects: 
+  objects:
     #- objectName: MONGO_HOST
     #  secretPath: testing/data/mongoDb
-    #  secretKey: MONGO_HOST  
+    #  secretKey: MONGO_HOST
   secretObjects:
     #- data:
     #  - key: MONGO_HOST
     #    objectName: host
     #  secretName: secret-mongo-host
-    #  type: Opaque  
-  
+    #  type: Opaque
+
 ##########################################################
 # Expose Application on Forecastle Dashboard
 # https://github.com/stakater/Forecastle
@@ -444,19 +444,19 @@ forecastle:
 
   # Add additional labels on Forecastle Custom Resource
   additionalLabels:
-  
+
   # URL of the icon for the custom app
   icon: https://raw.githubusercontent.com/stakater/ForecastleIcons/master/stakater-big.png
-  
+
   # Name of the application to be displayed on the Forecastle Dashboard
   displayName: "application"
-  
+
   # Group for the custom app (default: .Release.Namespace)
   group: ""
 
   # Add properties to Custom Resource
   properties:
-  
+
   # Whether app is network restricted or not
   networkRestricted: false
 
@@ -474,10 +474,18 @@ rbac:
     # Additional Labels on service account
     additionalLabels:
       # key: value
-    
-    # Annotations on service account 
+
+    # Annotations on service account
     annotations:
       # key: value
+
+  # Additional Labels on role and role bindings
+  additionalLabels:
+    # key: value
+
+  # Annotations on role and role bindings
+  annotations:
+    # key: value
 
   # Create Roles (Namespaced)
   roles:
@@ -503,9 +511,9 @@ rbac:
 ##########################################################
 configMap:
   enabled: false
-  additionalLabels: 
+  additionalLabels:
     # key: value
-  annotations: 
+  annotations:
     # key: value
   files:
     # nameSuffix of configMap
@@ -521,9 +529,9 @@ configMap:
 ##########################################################
 sealedSecret:
   enabled: false
-  additionalLabels: 
+  additionalLabels:
     #key: value
-  annotations: 
+  annotations:
     #key: value
   files:
 #  #nameSuffix of sealedSecret
@@ -544,9 +552,9 @@ sealedSecret:
 ##########################################################
 secret:
   enabled: false
-  additionalLabels: 
+  additionalLabels:
     # key: value
-  annotations: 
+  annotations:
     # key: value
   files:
 #  nameSuffix of Secret
@@ -564,7 +572,7 @@ secret:
 ##########################################################
 serviceMonitor:
   enabled: false
-  
+
   # Additional labels
   additionalLabels:
     # key: value
@@ -583,13 +591,13 @@ serviceMonitor:
 # HPA - Horizontal Pod Autoscaling
 ##########################################################
 autoscaling:
-# enabled is a boolean flag for enabling or disabling autoscaling 
+# enabled is a boolean flag for enabling or disabling autoscaling
   enabled: false
 # additionalLabels defines additional labels
-  additionalLabels: 
+  additionalLabels:
     # key: value
 # annotations defines annotations in key value pair
-  annotations: 
+  annotations:
     # key: value
 # minReplicas sets the minimum number of replicas
   minReplicas: 1
@@ -600,13 +608,13 @@ autoscaling:
   - type: Resource
     resource:
       name: cpu
-      target: 
+      target:
          type: Utilization
          averageUtilization: 60
   - type: Resource
     resource:
       name: memory
-      target: 
+      target:
          type: Utilization
          averageUtilization: 60
 
@@ -616,7 +624,7 @@ autoscaling:
 ##########################################################
 endpointMonitor:
   enabled: false
-  
+
   # Additional labels
   additionalLabels:
     # key: value
@@ -625,12 +633,15 @@ endpointMonitor:
   annotations:
     # key: value
 
+  # Additional configuration
+  additionalConfig:
+
 ##########################################################
 # Certficate CRD to generate the certificate
 ##########################################################
 certificate:
   enabled: false
-  
+
   # Additional labels
   additionalLabels:
     # key: value
@@ -689,12 +700,12 @@ certificate:
       name: test-creds
 
 ##########################################################
-# AlertmanagerConfig object for defining application 
+# AlertmanagerConfig object for defining application
 # specific alertmanager configurations
 ##########################################################
 alertmanagerConfig:
   enabled: false
-  
+
   # AlertmanagerConfig selectionLabels to specify label to be picked up by Alertmanager to add it to base config. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html] under .spec.alertmanagerConfigSelector
   selectionLabels:
     alertmanagerConfig: "workload"
@@ -724,12 +735,12 @@ alertmanagerConfig:
     #   equal: ['cluster', 'service']
 
 ##########################################################
-# PrometheusRule object for defining application 
+# PrometheusRule object for defining application
 # alerting rules
 ##########################################################
 prometheusRule:
   enabled: false
-  
+
   # PrometheusRule labels
   additionalLabels:
     # prometheus: stakater-workload-monitoring
@@ -747,7 +758,7 @@ prometheusRule:
     #       expr: up{namespace="test-app"} == 0
     #       for: 1m
     #       labels:
-    #         severity: critical  
+    #         severity: critical
 ##########################################################
 # External Secrets
 ##########################################################
@@ -757,23 +768,23 @@ externalSecret:
   # Default SecretStore for all externalsecrets defines which SecretStore to use when fetching the secret data
   secretStore:
     name: tenant-vault-secret-store
-    #kind: ClusterSecretStore # Defaults to SecretStore if not specified 
+    #kind: ClusterSecretStore # Defaults to SecretStore if not specified
 
   # RefreshInterval is the amount of time before the values reading again from the SecretStore provider
   refreshInterval: "1m"
-  files:   
+  files:
     # mongodb:
     # # Data defines the connection between the Kubernetes Secret keys and the Provider data
     #   data:
-    #      mongo-password: 
-    #        remoteRef: 
+    #      mongo-password:
+    #        remoteRef:
     #           key: monodb
-    #           property: passowrd 
-    #   secretStore:                       
-    #      name: secret-store-name-2    # specify if value is other than default secretstore  
+    #           property: passowrd
+    #   secretStore:
+    #      name: secret-store-name-2    # specify if value is other than default secretstore
     #   labels:
-    #      stakater.com/app: mongodb 
-    #   #     
+    #      stakater.com/app: mongodb
+    #   #
     # postgres:
       ## Used to fetch all properties from the Provider key
       #   dataFrom:
@@ -783,12 +794,12 @@ externalSecret:
 ##########################################################
 # Network Policy
 ##########################################################
-networkPolicy: 
+networkPolicy:
   enabled: false
   additionalLabels:
-  #   key: value
+    # key: value
   annotations:
-  #   key: value
+    # key: value
   ingress:
   # - from:
   #   - ipBlock:
@@ -818,15 +829,15 @@ networkPolicy:
 pdb:
   enabled: false
   minAvailable: 1
-# maxUnavailable: 1
+  maxUnavailable:
 
 ##########################################################
-# grafanaDashboard object for defining application 
+# grafanaDashboard object for defining application
 # Grafana Dashboard
 ##########################################################
 grafanaDashboard:
   enabled: false
-  
+
   # GrafanaDashboard additonal labels
   additionalLabels:
     # grafanaDashboard: grafana-operator
@@ -834,18 +845,18 @@ grafanaDashboard:
   # GrafanaDashboard annotations
   annotations:
     # key: value
-  
+
   # GrafanaDashboard contents
   # this includes pairs of dashboard name and associated json content
   # Accoroding to GrafanaDashboard behavior, if both url and json are specified then the GrafanaDashboard content will be updated with fetched content from url
   contents:
-    # dashboard-name-1: 
+    # dashboard-name-1:
     #   json: |-
     #     {
     #       "data"
     #     }
     #   url: http://hostname/path/to/file.json
-    # dashboard-name-2: 
+    # dashboard-name-2:
     #   json: |-
     #     {
     #       "data"


### PR DESCRIPTION
Hi, 

I used the stakater application charts for some deployement. 
I had see a limitation in some case. When I wanted to deploy the same application multiple time in the name namespace, because the charts didn't use the Helm Release.Name.

So I updated the _helper.tpl to generate an application fullname which use the Helm Release.Name and the applicationName. 

So the name of the deployed objects are {{ Release.Name }}-{{ applicationName }}

It's now possible to deploy multiple instance of the same value file in the same namespace. 

To to that 
I refactor labels and selectorLabels with 
 - app.kubernetes.io/instance:
 - app.kubernetes.io/component:
 - app.kubernetes.io/part-of:

Updated templates and value.yaml remove all trailing spaces.
