### PR TITLE
feat(cronjob): Add more properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 All notable changes to this project will be documented here.
 
-### v2.2.2
+### v2.2.3
 - feat: Add more properties to CronJob [PR-265](https://github.com/stakater/application/pull/265)
 
 ### v2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 All notable changes to this project will be documented here.
 
+### v2.1.20
+- feat: Add more properties to CronJob [PR-265](https://github.com/stakater/application/pull/265)
+
 ### v2.1.19
 - Fix: Reverts [PR-240](https://github.com/stakater/application/pull/240), It can already be configured via `paths` [PR-247](https://github.com/stakater/application/pull/247)
 

--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Job parameter for each cronjob object at `cronJob.jobs`
 | `<name>.additionalPodAnnotations`   | Additional annotations of pod of job          |
 | `<name>.additionalPodLabels`        | Additional labels of pod of job               |
 | `<name>.topologySpreadConstraints`  | TopologySpreadConstraints of pod of job       |
+| `<name>.securityContext`            | SecurityContext of pod of job                 |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Stakater [IngressMonitorController](https://github.com/stakater/IngressMonitorCo
 | `cronJob.enabled`        | Enable cronjob in application chart                                                          | `""`            |
 | `cronJob.jobs`           | cronjobs spec                                                                                | {}              |
 
-Job parameter for each cronjob object at `cronJob.jobs` 
+Job parameter for each cronjob object at `cronJob.jobs`
 
 | Name                                | Description                                   |
 | ----------------------------------- | --------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Job parameter for each cronjob object at `cronJob.jobs`
 | `<name>.activeDeadlineSeconds`      | ActiveDeadlineSeconds of job                  |
 | `<name>.additionalPodAnnotations`   | Additional annotations of pod of job          |
 | `<name>.additionalPodLabels`        | Additional labels of pod of job               |
+| `<name>.topologySpreadConstraints`  | TopologySpreadConstraints of pod of job       |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Stakater [IngressMonitorController](https://github.com/stakater/IngressMonitorCo
 | `cronJob.enabled`        | Enable cronjob in application chart                                                          | `""`            |
 | `cronJob.jobs`           | cronjobs spec                                                                                | {}              |
 
-Job paramater for each cronjob object at `cronJob.jobs` 
+Job parameter for each cronjob object at `cronJob.jobs` 
 
 | Name                               | Description                                                                                  
 | -----------------------------------| -------------------------------------------------------------------------------------------- |
@@ -447,7 +447,7 @@ Job paramater for each cronjob object at `cronJob.jobs`
 | `<name>.image.repository`          | Repository of container image of cronjob                                                     |
 | `<name>.image.tag`                 | Tag of container image of cronjob                                                            |
 | `<name>.image.digest`              | Digest of container image of cronjob                                                         |
-| `<name>.image.imagePullPolicy`     | ImagePullPolicy of container image ofcronjob                                                                                                                           |
+| `<name>.image.imagePullPolicy`     | ImagePullPolicy of container image of cronjob                                                                                                                           |
 | `<name>.command`                   | Command of container of job                                                                  |
 | `<name>.args`                      | Args of container of job                                                                     |
 | `<name>.resources`                 | Resources of container of job                                                                |
@@ -463,6 +463,8 @@ Job paramater for each cronjob object at `cronJob.jobs`
 | `<name>.tolerations`               | Tolerations of cronjob                                                                       | 
 | `<name>.restartPolicy`             | RestartPolicy of cronjob                                                                     |
 | `<name>.imagePullSecrets`          | ImagePullSecrets of cronjob                                                                     |
+| `<name>.activeDeadlineSeconds` | ActiveDeadlineSeconds of job |
+| `<name>.additionalPodAnnotations` | Additional annotations of pod of job |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 

--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Job parameter for each cronjob object at `cronJob.jobs`
 | `<name>.imagePullSecrets`           | ImagePullSecrets of cronjob                   |
 | `<name>.activeDeadlineSeconds`      | ActiveDeadlineSeconds of job                  |
 | `<name>.additionalPodAnnotations`   | Additional annotations of pod of job          |
+| `<name>.additionalPodLabels`        | Additional labels of pod of job               |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 

--- a/README.md
+++ b/README.md
@@ -441,30 +441,30 @@ Stakater [IngressMonitorController](https://github.com/stakater/IngressMonitorCo
 
 Job parameter for each cronjob object at `cronJob.jobs` 
 
-| Name                               | Description                                                                                  
-| -----------------------------------| -------------------------------------------------------------------------------------------- |
-| `<name>.schedule`                  | Schedule of cronjob                                                                          | 
-| `<name>.image.repository`          | Repository of container image of cronjob                                                     |
-| `<name>.image.tag`                 | Tag of container image of cronjob                                                            |
-| `<name>.image.digest`              | Digest of container image of cronjob                                                         |
-| `<name>.image.imagePullPolicy`     | ImagePullPolicy of container image of cronjob                                                                                                                           |
-| `<name>.command`                   | Command of container of job                                                                  |
-| `<name>.args`                      | Args of container of job                                                                     |
-| `<name>.resources`                 | Resources of container of job                                                                |
-| `<name>.additionalLabels`          | Additional labels of cronjob                                                                 |
-| `<name>.annotations`               | Annotation of cronjob                                                                        |    
-| `<name>.successfulJobsHistoryLimit`| Successful jobs historyLimit of cronjob                                                                           |    
-| `<name>.concurrencyPolicy`         | ConcurrencyPolicy of cronjob                                                                 |    
-| `<name>.failedJobsHistoryLimit`    | FailedJobsHistoryLimit of cronjob                                                            |    
-| `<name>.volumeMounts`              | Volume mounts  of cronjob                                                                    |  
-| `<name>.volumes`                    | Volumes  of cronjob                                                                          | 
-| `<name>.nodeSelector`              | Node selector of cronjob                                                                     | 
-| `<name>.affinity`                  | Affinity of cronjob                                                                          | 
-| `<name>.tolerations`               | Tolerations of cronjob                                                                       | 
-| `<name>.restartPolicy`             | RestartPolicy of cronjob                                                                     |
-| `<name>.imagePullSecrets`          | ImagePullSecrets of cronjob                                                                     |
-| `<name>.activeDeadlineSeconds` | ActiveDeadlineSeconds of job |
-| `<name>.additionalPodAnnotations` | Additional annotations of pod of job |
+| Name                                | Description                                   |
+| ----------------------------------- | --------------------------------------------- |
+| `<name>.schedule`                   | Schedule of cronjob                           |
+| `<name>.image.repository`           | Repository of container image of cronjob      |
+| `<name>.image.tag`                  | Tag of container image of cronjob             |
+| `<name>.image.digest`               | Digest of container image of cronjob          |
+| `<name>.image.imagePullPolicy`      | ImagePullPolicy of container image of cronjob |
+| `<name>.command`                    | Command of container of job                   |
+| `<name>.args`                       | Args of container of job                      |
+| `<name>.resources`                  | Resources of container of job                 |
+| `<name>.additionalLabels`           | Additional labels of cronjob                  |
+| `<name>.annotations`                | Annotation of cronjob                         |
+| `<name>.successfulJobsHistoryLimit` | Successful jobs historyLimit of cronjob       |
+| `<name>.concurrencyPolicy`          | ConcurrencyPolicy of cronjob                  |
+| `<name>.failedJobsHistoryLimit`     | FailedJobsHistoryLimit of cronjob             |
+| `<name>.volumeMounts`               | Volume mounts  of cronjob                     |
+| `<name>.volumes`                    | Volumes  of cronjob                           |
+| `<name>.nodeSelector`               | Node selector of cronjob                      |
+| `<name>.affinity`                   | Affinity of cronjob                           |
+| `<name>.tolerations`                | Tolerations of cronjob                        |
+| `<name>.restartPolicy`              | RestartPolicy of cronjob                      |
+| `<name>.imagePullSecrets`           | ImagePullSecrets of cronjob                   |
+| `<name>.activeDeadlineSeconds`      | ActiveDeadlineSeconds of job                  |
+| `<name>.additionalPodAnnotations`   | Additional annotations of pod of job          |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 

--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ Job parameter for each cronjob object at `cronJob.jobs`
 | `<name>.restartPolicy`              | RestartPolicy of cronjob                      |
 | `<name>.imagePullSecrets`           | ImagePullSecrets of cronjob                   |
 | `<name>.activeDeadlineSeconds`      | ActiveDeadlineSeconds of job                  |
+| `<name>.backoffLimit`               | BackoffLimit of job                           |
 | `<name>.additionalPodAnnotations`   | Additional annotations of pod of job          |
 | `<name>.additionalPodLabels`        | Additional labels of pod of job               |
 | `<name>.topologySpreadConstraints`  | TopologySpreadConstraints of pod of job       |

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
       {{- with $job.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ . }}
       {{- end }}
-      {{- if not (isNil $job.backoffLimit) }}
+      {{- if not (kindIs "invalid" $job.backoffLimit) }}
       backoffLimit: {{ $job.backoffLimit }}
       {{- end }}
       template:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -37,9 +37,9 @@ spec:
       template:
         metadata:
           labels:
-          {{- include "application.labels" $ | nindent 12 }}
+          {{- include "application.labels" $ | indent 12 }}
           {{- with $job.additionalPodLabels }}
-          {{- toYaml . | indent 12 }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with $job.additionalPodAnnotations }}
           annotations: {{ toYaml . | nindent 12 }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -37,7 +37,7 @@ spec:
       template:
         metadata:
           labels:
-          {{- include "application.labels" $ | indent 12 }}
+          {{- include "application.labels" $ | nindent 12 }}
           {{- with $job.additionalPodLabels }}
           {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -38,6 +38,10 @@ spec:
         metadata:
           labels:
           {{- include "application.labels" $ | nindent 12 }}
+          {{- with $job.additionalPodAnnotations }}
+          annotations:
+{{ toYaml . | indent 12 }}
+          {{- end }}
         spec:
           {{- if $.Values.rbac.serviceAccount.name }}
           serviceAccountName: {{ $.Values.rbac.serviceAccount.name }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -38,6 +38,9 @@ spec:
         metadata:
           labels:
           {{- include "application.labels" $ | nindent 12 }}
+          {{- with $job.additionalPodLabels }}
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $job.additionalPodAnnotations }}
           annotations: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
           labels:
           {{- include "application.labels" $ | nindent 12 }}
           {{- with $job.additionalPodLabels }}
-          {{ toYaml . | nindent 12 }}
+          {{- toYaml . | indent 12 }}
           {{- end }}
           {{- with $job.additionalPodAnnotations }}
           annotations: {{ toYaml . | nindent 12 }}
@@ -96,16 +96,13 @@ spec:
 {{ toYaml . | indent 12 }}
           {{- end }}
           {{- with $job.tolerations }}
-          tolerations:
-{{ toYaml . | indent 12 }}
+          tolerations: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- with $job.topologySpreadConstraints }}
-          topologySpreadConstraints:
-{{ toYaml . | indent 12 }}
+          topologySpreadConstraints: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- with $job.securityContext }}
-          securityContext:
-{{ toYaml . | indent 12 }}
+          securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- if $job.restartPolicy}}
           restartPolicy: {{ $job.restartPolicy }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -31,10 +31,10 @@ spec:
 {{ end }}
   jobTemplate:
     spec:
-      {{- if $job.activeDeadlineSeconds }}
-      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds }}
+      {{- with $job.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ . }}
       {{- end }}
-      {{- if $job.backoffLimit }}
+      {{- if not isNil $job.backoffLimit }}
       backoffLimit: {{ $job.backoffLimit }}
       {{- end }}
       template:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -31,9 +31,9 @@ spec:
 {{ end }}
   jobTemplate:
     spec:
-{{- with $job.activeDeadlineSeconds }}
+      {{- with $job.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ . }}
-{{- end }}
+      {{- end }}
       template:
         metadata:
           labels:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -31,6 +31,9 @@ spec:
 {{ end }}
   jobTemplate:
     spec:
+{{- if $job.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds }}
+{{ end }}
       template:
         metadata:
           labels:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -31,11 +31,11 @@ spec:
 {{ end }}
   jobTemplate:
     spec:
-      {{- with $job.activeDeadlineSeconds }}
-      activeDeadlineSeconds: {{ . }}
+      {{- if $job.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds }}
       {{- end }}
-      {{- with $job.backoffLimit }}
-      backoffLimit: {{ . }}
+      {{- if $job.backoffLimit }}
+      backoffLimit: {{ $job.backoffLimit }}
       {{- end }}
       template:
         metadata:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -99,6 +99,10 @@ spec:
           tolerations:
 {{ toYaml . | indent 12 }}
           {{- end }}
+          {{- with $job.topologySpreadConstraints }}
+          topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           {{- if $job.restartPolicy}}
           restartPolicy: {{ $job.restartPolicy }}
           {{ else }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -34,6 +34,9 @@ spec:
       {{- with $job.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ . }}
       {{- end }}
+      {{- with $job.backoffLimit }}
+      backoffLimit: {{ . }}
+      {{- end }}
       template:
         metadata:
           labels:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -103,6 +103,10 @@ spec:
           topologySpreadConstraints:
 {{ toYaml . | indent 12 }}
           {{- end }}
+          {{- with $job.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           {{- if $job.restartPolicy}}
           restartPolicy: {{ $job.restartPolicy }}
           {{ else }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -31,8 +31,8 @@ spec:
 {{ end }}
   jobTemplate:
     spec:
-{{- if $job.activeDeadlineSeconds }}
-      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds }}
+{{- with $job.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ . }}
 {{- end }}
       template:
         metadata:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
       {{- with $job.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ . }}
       {{- end }}
-      {{- if not isNil $job.backoffLimit }}
+      {{- if not (isNil $job.backoffLimit) }}
       backoffLimit: {{ $job.backoffLimit }}
       {{- end }}
       template:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -33,14 +33,13 @@ spec:
     spec:
 {{- if $job.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ $job.activeDeadlineSeconds }}
-{{ end }}
+{{- end }}
       template:
         metadata:
           labels:
           {{- include "application.labels" $ | nindent 12 }}
           {{- with $job.additionalPodAnnotations }}
-          annotations:
-{{ toYaml . | indent 12 }}
+          annotations: {{ toYaml . | nindent 12 }}
           {{- end }}
         spec:
           {{- if $.Values.rbac.serviceAccount.name }}


### PR DESCRIPTION
This PR adds support for the following properties in CronJob:
- `.spec.jobTemplate.spec.activeDeadlineSeconds`
- `.spec.jobTemplate.spec.backoffLimit`
- `.spec.jobTemplate.spec.template.metadata.annotations`
- `.spec.jobTemplate.spec.template.metadata.labels`
- `.spec.jobTemplate.spec.template.spec.topologySpreadConstraints`
- `.spec.jobTemplate.spec.template.spec.securityContext`