### PR TITLE
fix: allow multiple cronjobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 All notable changes to this project will be documented here.
 
+### v2.2.6
+- fix: allow multiple cronjobs [PR-271](https://github.com/stakater/application/pull/271)
+
 ### v2.2.5
 - fix: Namespace selector fixed for service monitor [PR-270](https://github.com/stakater/application/pull/270)
 

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -60,3 +60,11 @@ Allow the release namespace to be overridden
 {{- define "application.namespace" -}}
 {{- default .Release.Namespace .Values.namespaceOverride -}}
 {{- end -}}
+
+{{- define "application.sa.oauth-redirectreference" }}
+apiVersion: v1
+kind: OAuthRedirectReference
+reference:
+  kind: Route
+  name: {{ include "application.name" . }}
+{{- end }}

--- a/application/templates/alertmanagerconfig.yaml
+++ b/application/templates/alertmanagerconfig.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.alertmanagerConfig).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1alpha1") -}}
+---
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:

--- a/application/templates/certificate.yaml
+++ b/application/templates/certificate.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.certificate).enabled (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/application/templates/configmap.yaml
+++ b/application/templates/configmap.yaml
@@ -1,5 +1,6 @@
 {{- if (.Values.configMap).enabled }}
 {{- range $nameSuffix, $data := .Values.configMap.files }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,6 +17,5 @@ metadata:
 {{- end }}
 data:
 {{ include "application.tplvalues.render" ( dict "value" $data "context" $ ) | indent 2 }}
----
 {{- end }}
 {{- end }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -1,5 +1,6 @@
 {{- if (.Values.cronJob).enabled }}
 {{- range $name, $job := .Values.cronJob.jobs }}
+---
 {{ if $.Capabilities.APIVersions.Has "batch/v1/CronJob" -}}
 apiVersion: batch/v1
 {{- else -}}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.deployment.enabled }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/application/templates/endpointmonitor.yaml
+++ b/application/templates/endpointmonitor.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.endpointMonitor).enabled (.Capabilities.APIVersions.Has "endpointmonitor.stakater.com/v1alpha1") (or (and .Values.route .Values.route.enabled) (and .Values.ingress .Values.ingress.enabled))}}
+---
 apiVersion: endpointmonitor.stakater.com/v1alpha1
 kind: EndpointMonitor
 metadata:

--- a/application/templates/externalsecrets.yaml
+++ b/application/templates/externalsecrets.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.externalSecret).enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 {{- range $nameSuffix, $data := .Values.externalSecret.files }}
+---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -48,6 +49,5 @@ spec:
 {{ toYaml $data.labels | indent 10 }}
 {{- end }}
 {{- end }}
----
-{{- end}}
-{{- end}}
+{{- end }}
+{{- end }}

--- a/application/templates/forecastle.yaml
+++ b/application/templates/forecastle.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.forecastle).enabled (.Capabilities.APIVersions.Has "forecastle.stakater.com/v1alpha1") (or .Values.ingress.enabled .Values.route.enabled) }}
+---
 apiVersion: forecastle.stakater.com/v1alpha1
 kind: ForecastleApp
 metadata:

--- a/application/templates/grafanadashboard.yaml
+++ b/application/templates/grafanadashboard.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.grafanaDashboard).enabled (.Capabilities.APIVersions.Has "integreatly.org/v1alpha1") -}}
 {{- range $name, $content := .Values.grafanaDashboard.contents }}
+---
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
@@ -24,6 +25,5 @@ spec:
   {{- if $content.url }}
   url: {{ $content.url }}
   {{- end }}
----
 {{- end }}
 {{- end }}

--- a/application/templates/hpa.yaml
+++ b/application/templates/hpa.yaml
@@ -1,11 +1,10 @@
 {{- if and .Values.autoscaling.enabled .Values.deployment.enabled }}
-
+---
 {{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
 apiVersion: autoscaling/v2
 {{- else }}
 apiVersion: autoscaling/v2beta2
 {{- end }}
-
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "application.name" . }}

--- a/application/templates/ingress.yaml
+++ b/application/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if (.Values.ingress).enabled -}}
+---
 {{- $servicePort := .Values.ingress.servicePort -}}
 {{- $pathType := .Values.ingress.pathType -}}
 {{- $applicationNameTpl := include "application.name" . -}}

--- a/application/templates/networkpolicy.yaml
+++ b/application/templates/networkpolicy.yaml
@@ -1,4 +1,5 @@
 {{- if (.Values.networkPolicy).enabled }}
+---
 apiVersion: "networking.k8s.io/v1"
 kind: NetworkPolicy
 metadata:

--- a/application/templates/pdb.yaml
+++ b/application/templates/pdb.yaml
@@ -1,11 +1,10 @@
 {{- if or .Values.pdb.minAvailable .Values.pdb.maxUnavailable | and .Values.pdb.enabled }}
-
+---
 {{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1
 {{- end }}
-
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/application/templates/prometheusrule.yaml
+++ b/application/templates/prometheusrule.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.prometheusRule).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/application/templates/pvc.yaml
+++ b/application/templates/pvc.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.persistence).enabled (not .Values.persistence.existingClaim) }}
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/application/templates/role.yaml
+++ b/application/templates/role.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.rbac).enabled .Values.rbac.roles }}
 {{- range .Values.rbac.roles }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -16,6 +17,5 @@ metadata:
 {{- end }}
 rules:
 {{ toYaml .rules | indent 2 }}
----
 {{- end }}
 {{- end }}

--- a/application/templates/rolebinding.yaml
+++ b/application/templates/rolebinding.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.rbac).enabled .Values.rbac.roles }}
 {{- range .Values.rbac.roles }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -26,6 +27,5 @@ subjects:
     name: {{ template "application.name" $ }}
   {{- end }}
     namespace: {{ $.Release.Namespace }}
----
 {{- end }}
 {{- end }}

--- a/application/templates/route.yaml
+++ b/application/templates/route.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.route).enabled (.Capabilities.APIVersions.Has "route.openshift.io/v1") -}}
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/application/templates/sealedsecrets.yaml
+++ b/application/templates/sealedsecrets.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.sealedSecret) (.Capabilities.APIVersions.Has "bitnami.com/v1alpha1") }}
 {{- range $nameSuffix, $config := .Values.sealedSecret.files }}
+---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
@@ -56,6 +57,5 @@ spec:
       {{ toYaml $.Values.sealedSecret.additionalLabels | indent 2 }}
       {{- end }}
       {{- end }}
----
 {{- end }}
 {{- end }}

--- a/application/templates/secret.yaml
+++ b/application/templates/secret.yaml
@@ -1,5 +1,6 @@
 {{- if (.Values.secret).enabled }}
 {{- range $nameSuffix, $data := .Values.secret.files }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,6 +19,5 @@ data:
 {{- range $key, $value := .data }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
----
 {{- end }}
 {{- end }}

--- a/application/templates/secretproviderclass.yaml
+++ b/application/templates/secretproviderclass.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.secretProviderClass).enabled (.Capabilities.APIVersions.Has "secrets-store.csi.x-k8s.io/v1alpha1") }}
+---
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:

--- a/application/templates/service.yaml
+++ b/application/templates/service.yaml
@@ -1,4 +1,5 @@
 {{- if (.Values.service).enabled }}
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/application/templates/serviceaccount.yaml
+++ b/application/templates/serviceaccount.yaml
@@ -1,12 +1,5 @@
-{{- define "application.sa.oauth-redirectreference" }}
-apiVersion: v1
-kind: OAuthRedirectReference
-reference:
-  kind: Route
-  name: {{ include "application.name" . }}
-{{- end }}
-
 {{- if and .Values.rbac.enabled .Values.rbac.serviceAccount.enabled }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -17,12 +10,10 @@ metadata:
     {{- with .Values.rbac.serviceAccount.additionalLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-
   annotations:
     {{- with .Values.rbac.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-
     {{- if .Values.deployment.openshiftOAuthProxy.enabled }}
     serviceaccounts.openshift.io/oauth-redirectreference.primary:
       {{- $reference := include "application.sa.oauth-redirectreference" . | fromYaml }}

--- a/application/templates/servicemonitor.yaml
+++ b/application/templates/servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.serviceMonitor).enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+---
 apiVersion: "monitoring.coreos.com/v1"
 kind: ServiceMonitor
 metadata:

--- a/application/templates/vpa.yaml
+++ b/application/templates/vpa.yaml
@@ -2,6 +2,7 @@
 {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
   {{- fail "There is no VerticalPodAutoscaler resource definition in the target cluster!" }}
 {{- end }}
+---
 apiVersion: "autoscaling.k8s.io/v1"
 kind: VerticalPodAutoscaler
 metadata:


### PR DESCRIPTION
The cronjob template misses a `---` new document separation. This means all cronjobs are scrambled together and only a frankenstein version of all of them is emitted. 
This PR also does some lint:
- move the new document separator to the beginning of templates
- add empty newline at the end of files
- remove empty newlines in the middle of files
- move helpers to _helpers file.