### PR TITLE
Allow configuration of vpa.updatePolicy

### DIFF
--- a/application/templates/vpa.yaml
+++ b/application/templates/vpa.yaml
@@ -25,4 +25,6 @@ spec:
   resourcePolicy:
     containerPolicies:
       {{- toYaml .Values.vpa.containerPolicies | nindent 6 }}
+  updatePolicy:
+    {{- toYaml .Values.vpa.updatePolicy | nindent 4 }}
 {{- end }}

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -633,6 +633,8 @@ vpa:
     # key: value
 # container policies for individual containers.
   containerPolicies: []
+  updatePolicy:
+    updateMode: Auto
     
 ##########################################################
 # EndpointMonitor for IMC


### PR DESCRIPTION
Support for vpa.updatePolicy.updateMode=Auto|Recreate|Initial|Off (default is Auto)

```
$ helm template application --set=vpa.enabled='true' --validate | grep -A1 updatePolicy
  updatePolicy:
    updateMode: Auto
```

also works for other updatePolicy settings

```
$ helm template application --set=vpa.enabled='true' \
  --set=vpa.updatePolicy.updateMode=Off \
  --set=vpa.updatePolicy.minReplicas=3 --validate | grep -A2 updatePolicy
  updatePolicy:
    minReplicas: 3
    updateMode: "Off"
```

Link to CRD for reference: https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-1.0.0/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml#L377