### PR TITLE
Fix bug with secrets being empty

### DIFF
--- a/application/templates/secret.yaml
+++ b/application/templates/secret.yaml
@@ -16,7 +16,7 @@ metadata:
 {{ toYaml $.Values.secret.annotations | indent 4 }}
 {{- end }}
 data:
-{{- range $key, $value := .data }}
+{{- range $key, $value := $data }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The secret data is empty until I use dollar sign.

Here's my values.yaml example that doesn't work as expected
```
secret:
  enabled: true
  files:
    credentials:
      SECRET: <my_secret>
```
