### PR TITLE
Adds Jobs feature to the chart.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 All notable changes to this project will be documented here.
 
+### Unreleased
+
+#### Feature
+
+- Feature: Add Job template
+
 ### v4.1.3
 - BugFix: Only add application name label to Backup Template 
 

--- a/README.md
+++ b/README.md
@@ -490,6 +490,40 @@ Job parameter for each cronjob object at `cronJob.jobs`
 | `<name>.topologySpreadConstraints`  | TopologySpreadConstraints of pod of job                        |
 | `<name>.securityContext`            | SecurityContext of pod of job                                  |
 
+### Job Parameters
+
+| Name                     | Description                                                                                  | Value           |
+| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
+| `job.enabled`            | Enable job in application chart                                                              | `""`            |
+| `job.jobs`               | jobs spec                                                                                    | {}              |
+
+Job parameter for each job object at `job.jobs`
+
+| Name                                | Description                                   |
+| ----------------------------------- | --------------------------------------------- |
+| `<name>.image.repository`           | Repository of container image of job          |
+| `<name>.image.tag`                  | Tag of container image of job                 |
+| `<name>.image.digest`               | Digest of container image of job              |
+| `<name>.image.imagePullPolicy`      | ImagePullPolicy of container image of job     |
+| `<name>.command`                    | Command of container of job                   |
+| `<name>.args`                       | Args of container of job                      |
+| `<name>.resources`                  | Resources of container of job                 |
+| `<name>.additionalLabels`           | Additional labels of job                      |
+| `<name>.annotations`                | Annotation of job                             |
+| `<name>.volumeMounts`               | Volume mounts  of job                         |
+| `<name>.volumes`                    | Volumes  of job                               |
+| `<name>.nodeSelector`               | Node selector of job                          |
+| `<name>.affinity`                   | Affinity of job                               |
+| `<name>.tolerations`                | Tolerations of job                            |
+| `<name>.restartPolicy`              | RestartPolicy of job                          |
+| `<name>.imagePullSecrets`           | ImagePullSecrets of job                       |
+| `<name>.activeDeadlineSeconds`      | ActiveDeadlineSeconds of job                  |
+| `<name>.backoffLimit`               | BackoffLimit of job                           |
+| `<name>.additionalPodAnnotations`   | Additional annotations of pod of job          |
+| `<name>.additionalPodLabels`        | Additional labels of pod of job               |
+| `<name>.topologySpreadConstraints`  | TopologySpreadConstraints of pod of job       |
+| `<name>.securityContext`            | SecurityContext of pod of job                 |
+
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 
 Name format of ConfigMap, Secret, SealedSecret and ExternalSecret is ```{{ template "application.name" $ }}-{{ $nameSuffix }}``` then:

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -1,0 +1,115 @@
+{{- if (.Values.job).enabled }}
+{{- range $name, $job := .Values.job.jobs }}
+---
+{{ if $.Capabilities.APIVersions.Has "batch/v1/Job" -}}
+apiVersion: batch/v1
+{{- else -}}
+apiVersion: batch/v1beta1
+{{- end }}
+kind: Job
+metadata:
+  labels:
+  {{- include "application.labels" $ | nindent 4 }}
+{{- if $job.additionalLabels }}
+{{ $job.additionalLabels | indent 4 }}
+{{- end }}
+{{- if $job.annotations }}
+  annotations:
+{{ $job.annotations | indent 4 }}
+{{- end }}
+  name: {{ $name }}
+  namespace: {{ template "application.namespace" $ }}
+spec:
+  {{- with $job.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
+  {{- if not (kindIs "invalid" $job.backoffLimit) }}
+  backoffLimit: {{ $job.backoffLimit }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+      {{- include "application.labels" $ | nindent 8 }}
+      {{- with $job.additionalPodLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $job.additionalPodAnnotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if $.Values.rbac.enabled }}
+      {{- if $.Values.rbac.serviceAccount.name }}
+      serviceAccountName: {{ $.Values.rbac.serviceAccount.name }}
+        {{- else }}
+      serviceAccountName: {{ template "application.name" $ }}
+      {{- end }}
+      {{- end }}
+      containers:
+      - name: {{ $name }}
+
+        {{- $image := required (print "Undefined image repo for container '" $name "'") $job.image.repository }}
+        {{- with $job.image.tag    }} {{- $image = print $image ":" . }} {{- end }}
+        {{- with $job.image.digest }} {{- $image = print $image "@" . }} {{- end }}
+        image: {{ $image }}
+
+        {{- if $job.image.imagePullPolicy }}
+        imagePullPolicy: {{ $job.image.imagePullPolicy }}
+        {{ end }}
+        {{- with $job.env }}
+        env:
+        {{- range $key, $value := $job.env }}
+        - name: {{ include "application.tplvalues.render" ( dict "value" $key "context" $ ) }}
+{{ include "application.tplvalues.render" ( dict "value" $value "context" $ ) | indent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- with $job.envFrom }}
+        envFrom:
+{{ toYaml . | indent 8 }}
+        {{- end }}
+        {{- if $job.command }}
+        command: {{ $job.command }}
+        {{- end }}
+        {{- with $job.args }}
+        args:
+{{ toYaml . | indent 8 }}
+          {{- end }}
+        {{- with $job.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+        {{- with $job.volumeMounts }}
+        volumeMounts:
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      {{- with $job.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with $job.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with $job.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $job.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $job.securityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $job.restartPolicy}}
+      restartPolicy: {{ $job.restartPolicy }}
+      {{ else }}
+      restartPolicy: OnFailure
+      {{ end }}
+      {{- with $job.imagePullSecrets}}
+      imagePullSecrets: 
+{{ toYaml . | indent 8 }}
+      {{ end }}
+      {{- with $job.volumes }}
+      volumes:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -1,0 +1,97 @@
+suite: Job
+
+templates:
+  - job.yaml
+
+tests:
+  - it: does not fail rendering when job image tag and digest are absent
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: ""
+              digest: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-image
+
+  - it: fails rendering when job image repository is not given
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: ""
+              tag: doesnt
+              digest: matter
+    asserts:
+      - failedTemplate:
+          errorMessage: "Undefined image repo for container 'example'"
+
+  - it: uses tag when defined
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+              digest: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-image:example-tag
+
+  - it: uses digest when defined
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: ""
+              digest: sha256:example-digest
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-image@sha256:example-digest
+
+  - it: uses both tag and digest when given both
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+              digest: sha256:example-digest
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-image:example-tag@sha256:example-digest
+
+  - it: applies the additionalPodAnnotations correctly on the pods
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+              digest: sha256:example-digest
+            additionalPodAnnotations:
+              helm.sh/hook: "pre-install,pre-upgrade"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            helm.sh/hook: "pre-install,pre-upgrade"

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -1327,3 +1327,26 @@ backup:
     - events
     - resourcequotas
     - controllerrevisions.apps
+
+job: 
+  enabled: true
+  jobs:
+    db-migration:
+      additionalPodAnnotations:
+        helm.sh/hook: "pre-install,pre-upgrade"
+        helm.sh/hook-weight: "-1"
+        helm.sh/hook-delete-policy: "before-hook-creation"
+      imagePullSecrets:
+       - name: nexus-secret
+      image: 
+        repository: docker.io/nginx
+        tag: v1.0.0
+      env: 
+        KEY:
+          value: VALUE
+      command: ["/bin/bash"]
+      args: ["-c","sleep 5000"]
+      resources:  
+        requests:
+            memory: 5Gi
+            cpu: 1

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -39,6 +39,31 @@ cronJob:
     #         memory: 5Gi
     #         cpu: 1
   
+
+job:
+  enabled: false
+  jobs:
+    # db-migration:
+    #   additionalPodAnnotations:
+    #     helm.sh/hook: "pre-install,pre-upgrade"
+    #     helm.sh/hook-weight: "-1"
+    #     helm.sh/hook-delete-policy: "before-hook-creation"
+    #   env: 
+    #     KEY:
+    #       value: VALUE
+    #   image: 
+    #     repository: docker.io/nginx
+    #     tag: v1.0.0
+    #     digest: '' # if set to a non empty value, digest takes precedence on the tag
+    #     imagePullPolicy: IfNotPresent
+    #   command: ["/bin/bash"]
+    #   args: ["-c","sleep 5000"]
+    #   resources:  
+    #     requests:
+    #         memory: 5Gi
+    #         cpu: 1
+  
+
 ##########################################################
 # Deployment
 ##########################################################


### PR DESCRIPTION
Hey folks.
Thank you very much for maintaining this awesome chart!

This PR introduces the possibility of adding Jobs as part of the deployments.

The use case for this is quite simply to be able to utilize helm hooks for deployments (ie. for database migrations).

Currently, the implementation is very generic and could be used for any kind of purpose alongside the deployment (or CronJob). There is an alternative solution to this that I would also consider (and am happy to provide): Instead of making it very generic (and therefore flexible) we could add a "initJob" config tree to the deployment itself that would come preconfigured. There we would mirror the deployment configuration and behavior (env and such) to make it very simple to execute a helm hook.

Let me know what you think!