### PR TITLE
Add grpc probe to deployment

### DIFF
--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -199,6 +199,9 @@ spec:
           {{- else if .Values.deployment.startupProbe.tcpSocket }}
           tcpSocket:
             {{- toYaml .Values.deployment.startupProbe.tcpSocket | nindent 12 }}
+          {{- else if .Values.deployment.startupProbe.grpc }}
+          grpc:
+            {{- toYaml .Values.deployment.startupProbe.grpc | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- if .Values.deployment.livenessProbe.enabled }} 
@@ -217,6 +220,9 @@ spec:
           {{- else if .Values.deployment.livenessProbe.tcpSocket }}
           tcpSocket:
             {{- toYaml .Values.deployment.livenessProbe.tcpSocket | nindent 12 }}
+          {{- else if .Values.deployment.livenessProbe.grpc }}
+          grpc:
+            {{- toYaml .Values.deployment.livenessProbe.grpc | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- if .Values.deployment.readinessProbe.enabled }} 
@@ -235,6 +241,9 @@ spec:
           {{- else if .Values.deployment.readinessProbe.tcpSocket }}
           tcpSocket:
             {{- toYaml .Values.deployment.readinessProbe.tcpSocket | nindent 12 }}
+          {{- else if .Values.deployment.readinessProbe.grpc }}
+          grpc:
+            {{- toYaml .Values.deployment.readinessProbe.grpc | nindent 12 }}
           {{- end }}
         {{- end }}
       {{- if or (.Values.deployment.volumeMounts) (and (eq .Values.persistence.enabled true) (eq .Values.persistence.mountPVC true) )}} 

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -101,3 +101,24 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: example-app
+
+  - it: uses grpc probing when set
+    set:
+      applicationName: example-app
+      deployment.startupProbe.enabled: true
+      deployment.startupProbe.grpc.port: 5000
+      deployment.readinessProbe.enabled: true
+      deployment.readinessProbe.grpc.port: 5000
+      deployment.livenessProbe.enabled: true
+      deployment.livenessProbe.grpc.port: 5000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.grpc.port
+          value: 5000
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.grpc.port
+          value: 5000
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.grpc.port
+          value: 5000
+

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -209,6 +209,7 @@ deployment:
     httpGet: {}
     exec: {}
     tcpSocket: {}
+    grpc: {}
 
   readinessProbe:
     enabled: false
@@ -221,6 +222,7 @@ deployment:
     httpGet: {}
     exec: {}
     tcpSocket: {}
+    grpc: {}
 
   livenessProbe:
     enabled: false
@@ -233,6 +235,7 @@ deployment:
     httpGet: {}
     exec: {}
     tcpSocket: {}
+    grpc: {}
 
   # Resources to be defined for pod
   resources:


### PR DESCRIPTION
## What?
Add grpc probing to this Helm Chart.

## Why?
To allow developers to add probing to their grpc applications. 
https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/

## How?
By adding the option of configuring a grpc deployment probing in this Helm Chart.