### PR TITLE
ci: allow checkov to use kubeconfig

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   CHART_NAME: "application"
+  KUBECONFIG: "${{ github.workspace }}/.kubeconfig.yaml"
 
 jobs:
   build:


### PR DESCRIPTION
It passes down global envs to downstream docker runs https://github.com/aslafy-z/test-action/actions/runs/9908946364/job/27375873789