### PR TITLE
ci: pin helm-unittest version

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -98,3 +98,4 @@ jobs:
       - uses: d3adb5/helm-unittest-action@v2
         with:
           charts: application
+          unittest-version: v0.5.x


### PR DESCRIPTION
helm-unittest team released https://github.com/helm-unittest/helm-unittest/releases/tag/v0.5.2-test2 which breaks `helm plugin install https://github.com/helm-unittest/helm-unittest` (latest version).
Specifying `v0.5.x` takes the latest non-prerelease tag.