### PR TITLE
feat(deployment): support list of imagePullSecrets #major

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ helm delete --namespace test my-application
 | deployment.initContainers | object | `nil` | Add init containers to the pods. |
 | deployment.fluentdConfigAnnotations | object | `nil` | Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>. |
 | deployment.replicas | int | `nil` | Number of replicas. |
-| deployment.imagePullSecrets | string | `""` | Secret to be used for pulling the images (a single secret is supported). |
+| deployment.imagePullSecrets | list | `[]` | List of secrets to be used for pulling the images. |
 | deployment.envFrom | object | `nil` | Mount environment variables from ConfigMap or Secret to the pod. |
 | deployment.env | object | `nil` | Environment variables to be added to the pod. |
 | deployment.volumes | object | `nil` | Volumes to be added to the pod. Key is the name of the volume. Value is the volume definition. |

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -104,9 +104,9 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.deployment.imagePullSecrets }}
+      {{- with .Values.deployment.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ .Values.deployment.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         {{- if .Values.deployment.openshiftOAuthProxy.enabled }}

--- a/application/values-test.yaml
+++ b/application/values-test.yaml
@@ -70,7 +70,7 @@ deployment:
   replicas: 2
 
   # Secrets used to pull image
-  imagePullSecrets: ""
+  imagePullSecrets: []
 
   # If want to mount Envs from configmap or secret
   envFrom:

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -139,9 +139,10 @@ deployment:
   # -- (int) Number of replicas.
   # @section -- Deployment Parameters
   replicas:
-  # -- (string) Secret to be used for pulling the images (a single secret is supported).
+  # -- (list) List of secrets to be used for pulling the images.
   # @section -- Deployment Parameters
-  imagePullSecrets: ""
+  imagePullSecrets: []
+  #  - name: docker-pull
   # -- (object) Mount environment variables from ConfigMap or Secret to the pod.
   # @section -- Deployment Parameters
   envFrom:


### PR DESCRIPTION
This chart supports only one image pull secret instead of a list for the deployment.yml manifest. This Pull Request aims at supporting a list of secrets.