### PR TITLE
feat(cronjob): Corrected indentation of securityContext container params #minor

### DIFF
--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -97,7 +97,7 @@ spec:
 {{ toYaml . | indent 12 }}
             {{- end }}
             {{- with $job.securityContext }}
-            securityContext: {{ toYaml . | nindent 12 }}
+            securityContext: {{ toYaml . | nindent 14 }}
             {{- end }}
           {{- with $job.nodeSelector }}
           nodeSelector:

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -96,6 +96,9 @@ spec:
             volumeMounts:
 {{ toYaml . | indent 12 }}
             {{- end }}
+            {{- with $job.securityContext }}
+            securityContext: {{ toYaml . | nindent 12 }}
+            {{- end }}
           {{- with $job.nodeSelector }}
           nodeSelector:
 {{ toYaml . | indent 12 }}
@@ -112,9 +115,6 @@ spec:
           {{- end }}
           {{- with $job.topologySpreadConstraints }}
           topologySpreadConstraints: {{ toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with $job.securityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- if $job.restartPolicy }}
           restartPolicy: {{ $job.restartPolicy }}


### PR DESCRIPTION
Corrected the indentation level of securityContext to instead apply it to each container within the jobs.