### PR TITLE
fix: Remove default values for rollingUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ helm delete --namespace test my-application
 | deployment.annotations | object | `nil` | Annotations for Deployment. |
 | deployment.additionalPodAnnotations | object | `nil` | Additional pod annotations. |
 | deployment.strategy.type | string | `"RollingUpdate"` | Type of deployment strategy. |
-| deployment.strategy.rollingUpdate.maxUnavailable | string | `"25%"` | Max unavailable pods during update. |
-| deployment.strategy.rollingUpdate.maxSurge | string | `"25%"` | Max surge pods during update. |
 | deployment.reloadOnChange | bool | `true` | Reload deployment if attached Secret/ConfigMap changes. |
 | deployment.nodeSelector | object | `nil` | Select the node where the pods should be scheduled. |
 | deployment.hostAliases | list | `nil` | Add host aliases to the pods. |

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -92,13 +92,13 @@ deployment:
     # -- (string) Type of deployment strategy.
     # @section -- Deployment Parameters
     type: RollingUpdate
-    rollingUpdate:
+    # rollingUpdate:
       # -- (string) Max unavailable pods during update.
       # @section -- Deployment Parameters
-      maxUnavailable: 25%
+      # maxUnavailable: 25%
       # -- (string) Max surge pods during update.
       # @section -- Deployment Parameters
-      maxSurge: 25%
+      # maxSurge: 25%
   # -- (bool) Reload deployment if attached Secret/ConfigMap changes.
   # @section -- Deployment Parameters
   reloadOnChange: true

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -93,12 +93,8 @@ deployment:
     # @section -- Deployment Parameters
     type: RollingUpdate
     # rollingUpdate:
-      # -- (string) Max unavailable pods during update.
-      # @section -- Deployment Parameters
-      # maxUnavailable: 25%
-      # -- (string) Max surge pods during update.
-      # @section -- Deployment Parameters
-      # maxSurge: 25%
+    #   maxUnavailable: 25%
+    #   maxSurge: 25%
   # -- (bool) Reload deployment if attached Secret/ConfigMap changes.
   # @section -- Deployment Parameters
   reloadOnChange: true


### PR DESCRIPTION
RollingUpdate is an optional property only used when we set the strategy type as "RollingUpdate". If we set the type as "Recreate", this property breaks the deployments wit the following message:

Deployment.apps "<app>" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'

It gets more problematic when we use stakater/apps Helm Chart as a subchart for our applications. Helm has a known bug that doesn't allow override values from the subchart. So, if we need to deploy an application with the Recreate strategy, it is not possible as the deployment will always break with the error mentioned above.

The simpler solution is to comment the "rollingUpdate" property to prevent the Recreate deployments to break when using a subchart.