### PR TITLE
fix: allow disabling builtin service account

### DIFF
--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -54,12 +54,8 @@ spec:
           annotations: {{ toYaml . | nindent 12 }}
           {{- end }}
         spec:
-          {{- if $.Values.rbac.enabled }}
-          {{- if $.Values.rbac.serviceAccount.name }}
-          serviceAccountName: {{ $.Values.rbac.serviceAccount.name }}
-            {{- else }}
-          serviceAccountName: {{ template "application.name" $ }}
-          {{- end }}
+          {{- if and $.Values.rbac.enabled $.Values.rbac.serviceAccount.enabled }}
+          serviceAccountName: {{ default (include "application.name" $) $.Values.rbac.serviceAccount.name }}
           {{- end }}
           containers:
           - name: {{ $name }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -308,12 +308,8 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if .Values.rbac.serviceAccount.enabled }}
-      {{- if .Values.rbac.serviceAccount.name }}
-      serviceAccountName: {{ .Values.rbac.serviceAccount.name }}
-      {{- else }}
-      serviceAccountName: {{ template "application.name" $ }}
-      {{- end }}
+      {{- if and .Values.rbac.enabled .Values.rbac.serviceAccount.enabled }}
+      serviceAccountName: {{ default (include "application.name" .) .Values.rbac.serviceAccount.name }}
       {{- end }}
       {{- if .Values.deployment.hostNetwork }}
       hostNetwork: {{ .Values.deployment.hostNetwork }}

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -37,12 +37,8 @@ spec:
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- if $.Values.rbac.enabled }}
-      {{- if $.Values.rbac.serviceAccount.name }}
-      serviceAccountName: {{ $.Values.rbac.serviceAccount.name }}
-        {{- else }}
-      serviceAccountName: {{ template "application.name" $ }}
-      {{- end }}
+      {{- if and $.Values.rbac.enabled $.Values.rbac.serviceAccount.enabled }}
+      serviceAccountName: {{ default (include "application.name" $) $.Values.rbac.serviceAccount.name }}
       {{- end }}
       containers:
       - name: {{ $name }}


### PR DESCRIPTION
This PR fixes inconsistencies in handling custom service accounts by ensuring `serviceAccountName` is only set when both `rbac.enabled` and `rbac.serviceAccount.enabled` are `true` across `CronJob`, `Job`, and `Deployment` templates.

#### Motivation
Previously, templates could reference a service account even when it wasn’t created due to `rbac.serviceAccount.enabled` being `false`, causing unpredictable behavior. This change provides consistent, configurable handling.

#### Potential Impact
- Users relying on referencing non-existent service accounts may need to update configurations. (A future change will allow the use of a pre-existing service account)
- 

#### References
- Replaces #320
- [XKCD 1172](https://xkcd.com/1172/)