### PR TITLE
feat!: harmonize service account binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ helm delete --namespace test my-application
 | deployment.securityContext | object | `nil` | Security Context for the pod. |
 | deployment.command | list | `[]` | Command for the app container. |
 | deployment.args | list | `[]` | Args for the app container. |
-| deployment.automountServiceAccountToken | bool | `true` | Mount Service Account token. |
+| deployment.automountServiceAccountToken | bool | `false` | Mount Service Account token. |
 | deployment.ports | list | `nil` | List of ports for the app container. |
 | deployment.hostNetwork | bool | `nil` | Host network connectivity. |
 | deployment.terminationGracePeriodSeconds | int | `nil` | Gracefull termination period. |
@@ -241,12 +241,14 @@ helm delete --namespace test my-application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | rbac.enabled | bool | `true` | Enable RBAC. |
-| rbac.serviceAccount.enabled | bool | `false` | Deploy Service Account. |
-| rbac.serviceAccount.name | string | `{{ include "application.name" $ }}` | Service Account Name. |
-| rbac.serviceAccount.additionalLabels | object | `nil` | Additional labels for Service Account. |
-| rbac.serviceAccount.annotations | object | `nil` | Annotations for Service Account. |
+| rbac.serviceAccount.create | bool | `false` | Specifies whether to create a dedicated service account. If set to `true`, a new service account will be created. |
+| rbac.serviceAccount.name | string | `""` | The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`: If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account ("default") is used. If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used. If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template. If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation. |
+| rbac.serviceAccount.additionalLabels | object | `nil` | Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account. |
+| rbac.serviceAccount.annotations | object | `nil` | Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account. |
 | rbac.roles | list | `nil` | Role definitions scoped to a single namespace. |
 | rbac.clusterRoles | list | `nil` | ClusterRole definitions with cluster-wide permissions. |
+| rbac.additionalLabels | object | `nil` | Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
+| rbac.annotations | object | `nil` | Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
 
 ### ConfigMap Parameters
 

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -94,6 +94,21 @@ reference:
 {{- end }}
 
 {{/*
+Get the name of the service account to use.
+If the service account is set to be created, return the service account name or a default name.
+If the service account is not set to be created and a name is provided, return the provided name;
+otherwise, return the default namespace service account.
+*/}}
+{{- define "application.serviceAccountName" }}
+  {{- $saName := .Values.rbac.serviceAccount.name }}
+  {{- if .Values.rbac.serviceAccount.create }}
+    {{- empty $saName | ternary (include "application.name" .) (quote $saName) }}
+  {{- else }}
+    {{- empty $saName | ternary "default" (quote $saName) }}
+  {{- end }}
+{{- end }}
+
+{{/*
 Renders httpRoute rules with proper integer type for port fields.
 Usage:
 {{ include "application.httpRoute.rules" . }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -62,14 +62,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         spec:
-          automountServiceAccountToken: {{ kindIs "invalid" $job.automountServiceAccountToken | ternary true $job.automountServiceAccountToken }}
-          {{- if $.Values.rbac.enabled }}
-          {{- if $.Values.rbac.serviceAccount.name }}
-          serviceAccountName: {{ $.Values.rbac.serviceAccount.name }}
-            {{- else }}
-          serviceAccountName: {{ template "application.name" $ }}
-          {{- end }}
-          {{- end }}
+          automountServiceAccountToken: {{ $job.automountServiceAccountToken | default false }}
+          serviceAccountName: {{ include "application.serviceAccountName" $ }}
           {{- with $job.initContainers }}
           initContainers:
           {{- range $key, $value := . }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
           ]
 {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
+      serviceAccountName: {{ include "application.serviceAccountName" $ }}
       enableServiceLinks: {{ .Values.deployment.enableServiceLinks }}
       {{- with .Values.deployment.hostAliases }}
       hostAliases: {{- toYaml . | nindent 6 }}
@@ -327,14 +329,6 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if .Values.rbac.serviceAccount.enabled }}
-      {{- if .Values.rbac.serviceAccount.name }}
-      serviceAccountName: {{ .Values.rbac.serviceAccount.name }}
-      {{- else }}
-      serviceAccountName: {{ template "application.name" $ }}
-      {{- end }}
-      {{- end }}
-      automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       {{- if .Values.deployment.hostNetwork }}
       hostNetwork: {{ .Values.deployment.hostNetwork }}
       {{- end }}

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -42,14 +42,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      automountServiceAccountToken: {{ kindIs "invalid" $job.automountServiceAccountToken | ternary true $job.automountServiceAccountToken }}
-      {{- if $.Values.rbac.enabled }}
-      {{- if $.Values.rbac.serviceAccount.name }}
-      serviceAccountName: {{ $.Values.rbac.serviceAccount.name }}
-        {{- else }}
-      serviceAccountName: {{ template "application.name" $ }}
-      {{- end }}
-      {{- end }}
+      automountServiceAccountToken: {{ $job.automountServiceAccountToken | default false }}
+      serviceAccountName: {{ include "application.serviceAccountName" $ }}
       {{- with $job.initContainers }}
       initContainers:
       {{- range $key, $value := . }}

--- a/application/templates/rolebinding.yaml
+++ b/application/templates/rolebinding.yaml
@@ -21,11 +21,7 @@ roleRef:
   name: {{ template "application.name" $ }}-role-{{ .name }}
 subjects:
   - kind: ServiceAccount
-    {{- if $.Values.rbac.serviceAccount.name }}
-    name: {{ $.Values.rbac.serviceAccount.name }}
-    {{- else }}
-    name: {{ template "application.name" $ }}
-    {{- end }}
+    name: {{ include "application.serviceAccountName" $ }}
     namespace: {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/application/templates/serviceaccount.yaml
+++ b/application/templates/serviceaccount.yaml
@@ -1,9 +1,9 @@
-{{- if and .Values.rbac.enabled .Values.rbac.serviceAccount.enabled }}
+{{- if and .Values.rbac.enabled .Values.rbac.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default (include "application.name" .) .Values.rbac.serviceAccount.name }}
+  name: {{ include "application.serviceAccountName" . }}
   namespace: {{ template "application.namespace" . }}
   labels:
     {{- include "application.labels" $ | nindent 4 }}

--- a/application/tests/cronjob_test.yaml
+++ b/application/tests/cronjob_test.yaml
@@ -347,6 +347,57 @@ tests:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
           pattern: "@null"
 
+  - it: yields default service account name when create is disabled and no existing service account name is given
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            schedule: "0 * * * *"
+            image:
+              repository: example-image
+              tag: example-tag
+      rbac.serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: default
+
+  - it: uses service account name override when present
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            schedule: "0 * * * *"
+            image:
+              repository: example-image
+              tag: example-tag
+      rbac.serviceAccount.create: true
+      rbac.serviceAccount.name: example-sa
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: example-sa
+
+  - it: uses a generated service account name when not given
+    set:
+      applicationName: example-app
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            schedule: "0 * * * *"
+            image:
+              repository: example-image
+              tag: example-tag
+      rbac.serviceAccount.create: true
+      rbac.serviceAccount.name: ""
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: example-app
+
   - it: configures automount service account token by default
     set:
       cronJob:
@@ -359,9 +410,9 @@ tests:
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
-          value: true
+          value: false
 
-  - it: enable automount service account token when configured
+  - it: enables automountServiceAccountToken when explicitly set
     set:
       cronJob:
         enabled: true
@@ -375,21 +426,6 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
           value: true
-
-  - it: disable automount service account token when configured
-    set:
-      cronJob:
-        enabled: true
-        jobs:
-          example:
-            automountServiceAccountToken: false
-            image:
-              repository: example-image
-              tag: example-tag
-    asserts:
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
-          value: false
 
   - it: does not include enable service links by default
     set:

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -100,16 +100,17 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: "@null"
 
-  - it: yields empty service account name when disabled
+  - it: yields default service account name when create is disabled and no existing service account name is given
     set:
-      rbac.serviceAccount.enabled: false
+      rbac.serviceAccount.create: false
     asserts:
-      - notExists:
+      - equal:
           path: spec.template.spec.serviceAccountName
+          value: default
 
   - it: uses service account name override when present
     set:
-      rbac.serviceAccount.enabled: true
+      rbac.serviceAccount.create: true
       rbac.serviceAccount.name: example-sa
     asserts:
       - equal:
@@ -119,7 +120,7 @@ tests:
   - it: uses a generated service account name when not given
     set:
       applicationName: example-app
-      rbac.serviceAccount.enabled: true
+      rbac.serviceAccount.create: true
       rbac.serviceAccount.name: ""
     asserts:
       - equal:
@@ -130,15 +131,15 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
-          value: true
+          value: false
 
-  - it: disable automount service account token when configured
+  - it: enables automountServiceAccountToken when explicitly set
     set:
-      deployment.automountServiceAccountToken: false
+      deployment.automountServiceAccountToken: true
     asserts:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
-          value: false
+          value: true
 
   - it: uses grpc probing when set
     set:

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -346,6 +346,54 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: "@null"
 
+  - it: yields default service account name when create is disabled and no existing service account name is given
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+      rbac.serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: uses service account name override when present
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+      rbac.serviceAccount.create: true
+      rbac.serviceAccount.name: example-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: example-sa
+
+  - it: uses a generated service account name when not given
+    set:
+      applicationName: example-app
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+      rbac.serviceAccount.create: true
+      rbac.serviceAccount.name: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: example-app
+
   - it: configures automount service account token by default
     set:
       job:
@@ -358,9 +406,9 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
-          value: true
+          value: false
 
-  - it: enable automount service account token when configured
+  - it: enables automountServiceAccountToken when explicitly set
     set:
       job:
         enabled: true
@@ -374,21 +422,6 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: true
-
-  - it: disable automount service account token when configured
-    set:
-      job:
-        enabled: true
-        jobs:
-          example:
-            automountServiceAccountToken: false
-            image:
-              repository: example-image
-              tag: example-tag
-    asserts:
-      - equal:
-          path: spec.template.spec.automountServiceAccountToken
-          value: false
 
   - it: does not include enable service links by default
     set:

--- a/application/tests/rolebinding_test.yaml
+++ b/application/tests/rolebinding_test.yaml
@@ -121,6 +121,7 @@ tests:
         roles:
           - name: example
         serviceAccount:
+          create: true
           name: ""
     asserts:
       - equal:

--- a/application/tests/serviceaccount_test.yaml
+++ b/application/tests/serviceaccount_test.yaml
@@ -9,7 +9,7 @@ tests:
       rbac:
         enabled: false
         serviceAccount:
-          enabled: true
+          create: true
     asserts:
       - hasDocuments:
           count: 0
@@ -19,7 +19,7 @@ tests:
       rbac:
         enabled: true
         serviceAccount:
-          enabled: false
+          create: false
     asserts:
       - hasDocuments:
           count: 0
@@ -29,7 +29,7 @@ tests:
       rbac:
         enabled: true
         serviceAccount:
-          enabled: true
+          create: true
     asserts:
       - hasDocuments:
           count: 1
@@ -41,7 +41,7 @@ tests:
       rbac:
         enabled: true
         serviceAccount:
-          enabled: true
+          create: true
           additionalLabels:
             foo: bar
             test: ing
@@ -59,7 +59,7 @@ tests:
       rbac:
         enabled: true
         serviceAccount:
-          enabled: true
+          create: true
           annotations:
             foo: bar
             test: ing
@@ -76,7 +76,7 @@ tests:
       rbac:
         enabled: true
         serviceAccount:
-          enabled: true
+          create: true
     asserts:
       - matchRegex:
           path: metadata.annotations["serviceaccounts.openshift.io/oauth-redirectreference.primary"]
@@ -87,7 +87,7 @@ tests:
       rbac:
         enabled: true
         serviceAccount:
-          enabled: true
+          create: true
           name: example-name-that-should-be-used
     asserts:
       - equal:

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -487,7 +487,7 @@ deployment:
   args: []
   # -- (bool) Mount Service Account token.
   # @section -- Deployment Parameters
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   # -- (list) List of ports for the app container.
   # @section -- Deployment Parameters
   ports:
@@ -799,18 +799,21 @@ rbac:
   # @section -- RBAC Parameters
   enabled: true
   serviceAccount:
-    # -- (bool) Deploy Service Account.
+    # -- (bool) Specifies whether to create a dedicated service account. If set to `true`, a new service account will be created.
     # @section -- RBAC Parameters
-    enabled: false
-    # -- (string) Service Account Name.
-    # @default -- `{{ include "application.name" $ }}`
+    create: false
+    # -- (string) The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`:
+    # If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account ("default") is used.
+    # If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used.
+    # If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template.
+    # If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation.
     # @section -- RBAC Parameters
     name: ""
-    # -- (object) Additional labels for Service Account.
+    # -- (object) Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account.
     # @section -- RBAC Parameters
     additionalLabels:
       # key: value
-    # -- (object) Annotations for Service Account.
+    # -- (object) Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account.
     # @section -- RBAC Parameters
     annotations:
       # key: value
@@ -854,6 +857,14 @@ rbac:
   #     - get
   #     - list
   #     - watch
+  # -- (object) Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources.
+  # @section -- RBAC Parameters
+  additionalLabels:
+    # key: value
+  # -- (object) Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources.
+  # @section -- RBAC Parameters
+  annotations:
+    # key: value
 
 configMap:
   # -- (bool) Deploy additional ConfigMaps.


### PR DESCRIPTION
Closes #320
Closes #361

## Summary

- Rename `rbac.serviceAccount.enabled` to `rbac.serviceAccount.create`
- Change `deployment.automountServiceAccountToken` default from `true` to `false`
- Fix inconsistencies in serviceAccount binding across CronJob, Job, and Deployment templates by introducing a new `application.serviceAccountName` helper
- Restore per-resource `automountServiceAccountToken` toggles (defaults to `false`)
- Document missing Role and RoleBinding `rbac.annotations` and `rbac.additionalLabels` fields

## Breaking change

**1. `rbac.serviceAccount.enabled` is renamed to `rbac.serviceAccount.create`.**

If you currently have:

```yaml
rbac:
  serviceAccount:
    enabled: true
```

You must migrate to:

```yaml
rbac:
  serviceAccount:
    create: true
```

**2. `automountServiceAccountToken` now defaults to `false` everywhere.**

Previously, `deployment.automountServiceAccountToken` defaulted to `true`. It now defaults to `false` for Deployments, CronJobs, and Jobs.

If your workloads require a service account token (for example to call the Kubernetes API), you must explicitly opt in:

```yaml
deployment:
  automountServiceAccountToken: true
```

For CronJobs and Jobs, the toggle is per job entry:

```yaml
cronJob:
  jobs:
    example:
      automountServiceAccountToken: true
```

**3. ServiceAccount name resolution changed.**

The new `application.serviceAccountName` helper follows this logic:

| `rbac.serviceAccount.create` | `rbac.serviceAccount.name` | Result |
|-|-|-|
| `true` | `""` | `<release-name>` (from `application.name`) |
| `true` | `"foo"` | `"foo"` |
| `false` | `""` | `"default"` |
| `false` | `"bar"` | `"bar"` |

Previously, CronJob and Job templates did not consistently follow this resolution.

## Test plan

- [x] Helm unit tests updated for all three breaking changes
- [ ] Verify downstream charts that set `rbac.serviceAccount.enabled` are migrated
- [ ] Verify workloads that need API access explicitly set `automountServiceAccountToken: true`