### PR TITLE
feat: make cert manager certificate's commonName optional #major

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ helm delete --namespace test my-application
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
 | certificate.subject | tpl/object | `nil` | Full X509 name specification for certificate. |
-| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
+| certificate.commonName | tpl/string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
 | certificate.keyAlgorithm | string | `"rsa"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"pkcs1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ helm delete --namespace test my-application
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
 | certificate.subject | tpl/object | `nil` | Full X509 name specification for certificate. |
-| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com) |
+| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
 | certificate.keyAlgorithm | string | `"rsa"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"pkcs1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ helm delete --namespace test my-application
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
 | certificate.subject | tpl/object | `nil` | Full X509 name specification for certificate. |
-| certificate.commonName | string | `"admin-app"` | Common name as specified on the DER encoded CSR. |
+| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. |
 | certificate.keyAlgorithm | string | `"rsa"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"pkcs1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |

--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ helm delete --namespace test my-application
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
 | certificate.subject | tpl/object | `nil` | Full X509 name specification for certificate. |
-| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. |
-| certificate.keyAlgorithm | string | `"rsa"` | Private key algorithm of the corresponding private key for this certificate. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com) |
+| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com) |
+| certificate.keyAlgorithm | string | `"rsa"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"pkcs1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |
 | certificate.isCA | bool | `false` | Mark this Certificate as valid for certificate signing. |

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ helm delete --namespace test my-application
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
 | certificate.subject | tpl/object | `nil` | Full X509 name specification for certificate. |
-| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. |
+| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com) |
 | certificate.keyAlgorithm | string | `"rsa"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"pkcs1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |

--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ helm delete --namespace test my-application
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
 | certificate.subject | tpl/object | `nil` | Full X509 name specification for certificate. |
-| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com) |
-| certificate.keyAlgorithm | string | `"rsa"` | Private key algorithm of the corresponding private key for this certificate. |
+| certificate.commonName | string | `nil` | Common name as specified on the DER encoded CSR. |
+| certificate.keyAlgorithm | string | `"rsa"` | Private key algorithm of the corresponding private key for this certificate. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com) |
 | certificate.keyEncoding | string | `"pkcs1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |
 | certificate.isCA | bool | `false` | Mark this Certificate as valid for certificate signing. |

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -907,11 +907,11 @@ certificate:
   #    - Stockholm
   #  provinces:
   #    - Stockholm
-  # -- (string) Common name as specified on the DER encoded CSR.
+  # -- (string) Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com)
   # @section -- cert-manager Certificate Parameters
   commonName:
   # admin-app
-  # -- (string) Private key algorithm of the corresponding private key for this certificate. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com)
+  # -- (string) Private key algorithm of the corresponding private key for this certificate.
   # @section -- cert-manager Certificate Parameters
   keyAlgorithm: rsa
   # -- (string) Private key cryptography standards (PKCS) for this certificate's private key to be encoded in.

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -911,7 +911,7 @@ certificate:
   # @section -- cert-manager Certificate Parameters
   commonName:
   # admin-app
-  # -- (string) Private key algorithm of the corresponding private key for this certificate.
+  # -- (string) Private key algorithm of the corresponding private key for this certificate. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com)
   # @section -- cert-manager Certificate Parameters
   keyAlgorithm: rsa
   # -- (string) Private key cryptography standards (PKCS) for this certificate's private key to be encoded in.

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -900,7 +900,8 @@ certificate:
   #    - Stockholm
   # -- (string) Common name as specified on the DER encoded CSR.
   # @section -- cert-manager Certificate Parameters
-  commonName: admin-app
+  commonName:
+  # admin-app
   # -- (string) Private key algorithm of the corresponding private key for this certificate.
   # @section -- cert-manager Certificate Parameters
   keyAlgorithm: rsa

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -907,7 +907,7 @@ certificate:
   #    - Stockholm
   #  provinces:
   #    - Stockholm
-  # -- (string) Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com).
+  # -- (tpl/string) Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com).
   # @section -- cert-manager Certificate Parameters
   commonName:
   # commonName: admin-app

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -907,7 +907,7 @@ certificate:
   #    - Stockholm
   #  provinces:
   #    - Stockholm
-  # -- (string) Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com)
+  # -- (string) Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com).
   # @section -- cert-manager Certificate Parameters
   commonName:
   # commonName: admin-app

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -910,7 +910,7 @@ certificate:
   # -- (string) Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found [here](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com)
   # @section -- cert-manager Certificate Parameters
   commonName:
-  # admin-app
+  # commonName: admin-app
   # -- (string) Private key algorithm of the corresponding private key for this certificate.
   # @section -- cert-manager Certificate Parameters
   keyAlgorithm: rsa


### PR DESCRIPTION
Making `certificate.commonName` default to null. It should not default to `admin-app` as this field is optional. It can be set according to specific needs but it should not default to an irrelevant value. 

https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com

The main reason for making this change is that whenever we try to create `Certificate`, its `commonName` field defaults to `admin-app` which is unexpected behavior in default scenario. Setting it to `nil` will make more sense.