### PR TITLE
feat: add `extraObjects` list field

### DIFF
--- a/application/templates/extraobjects.yaml
+++ b/application/templates/extraobjects.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/application/tests/extraobjects_test.yaml
+++ b/application/tests/extraobjects_test.yaml
@@ -1,0 +1,55 @@
+suite: ConfigMap
+
+templates:
+  - extraobjects.yaml
+
+tests:
+  - it: does not yield objects if extraObjects is []
+    set:
+      extraObjects: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: yields one ConfigMap
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-config
+            namespace: test-namespace
+          data:
+            key1: value1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-config
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+
+  - it: yields multiple resources
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-config
+            namespace: test-namespace
+          data:
+            key1: value1
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-config2
+            namespace: test-namespace
+          data:
+            key1: value1
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -1232,3 +1232,29 @@ backup:
   # -- (list) List of resource types to exclude from the backup.
   # @section -- Backup Parameters
   excludedResources:
+
+# -- Array of extra K8s manifests to deploy
+extraObjects: []
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: app-server-sso
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "app/server/sso"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "client_id"
+  #                 objectAlias: "client_id"
+  #               - path: "client_secret"
+  #                 objectAlias: "client_secret"
+  #     secretObjects:
+  #     - data:
+  #       - key: client_id
+  #         objectName: client_id
+  #       - key: client_secret
+  #         objectName: client_secret
+  #       secretName: app-server-sso-secrets-store
+  #       type: Opaque


### PR DESCRIPTION
Introduce an `extraObjects` field to allow users to specify additional Kubernetes manifests.
This change includes tests to validate the behavior when the list is empty and when it contains one or multiple resources.

Closes #381