### PR TITLE
fix: remove newlines in rendered manifests

### DIFF
--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -137,12 +137,10 @@ spec:
           name: proxy-tls
         {{- end }}
       - name: {{ template "application.name" . }}
-
         {{- $image := required "Undefined image for application container" .Values.deployment.image.repository }}
         {{- with .Values.deployment.image.tag    }} {{- $image = print $image ":" . }} {{- end }}
         {{- with .Values.deployment.image.digest }} {{- $image = print $image "@" . }} {{- end }}
         image: {{ $image }}
-
         imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
         {{- with .Values.deployment.lifecycle }}
         lifecycle:

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -45,12 +45,10 @@ spec:
       {{- end }}
       containers:
       - name: {{ $name }}
-
         {{- $image := required (print "Undefined image repo for container '" $name "'") $job.image.repository }}
         {{- with $job.image.tag    }} {{- $image = print $image ":" . }} {{- end }}
         {{- with $job.image.digest }} {{- $image = print $image "@" . }} {{- end }}
         image: {{ $image }}
-
         {{- if $job.image.imagePullPolicy }}
         imagePullPolicy: {{ $job.image.imagePullPolicy }}
         {{ end }}


### PR DESCRIPTION
Remove extra newlines in deployment and job manifests that leaks to rendered manifests.