### PR TITLE
fix(service): remove podLabels from Service selector

### DIFF
--- a/application/templates/service.yaml
+++ b/application/templates/service.yaml
@@ -34,9 +34,6 @@ spec:
   {{- end }}
   selector:
 {{ include "application.selectorLabels" . | indent 4 }}
-{{- if .Values.deployment.podLabels }}
-{{ toYaml .Values.deployment.podLabels | indent 4 }}
-{{- end }}
   ports:
   {{- if .Values.deployment.openshiftOAuthProxy.enabled }}
   - name: proxy


### PR DESCRIPTION
Hi, 

I try your generic chart, and I need to customize labels of deployment with deployment.podLabels.

This works fine for deployment, as it only adds the label to spec.template.metadata.labels (example deployTimestamp label), not to spec.selector.matchLabels.

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: api-1
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: api-1
  template:
    metadata:
      labels:
        app.kubernetes.io/name: api-1
        deployTimestamp: '1751286504'
```

However, this is also added to the selector on the service. During a rolling update, the service is updated with a changing label and can no longer reach the old pods, so there's a 503 error until at least one new pod is launched.

I think it's better to stay consistent with the deployment's spec.selector.matchLabels

```
apiVersion: v1
kind: Service
metadata:
  name: api-1
spec:
  selector:
    app.kubernetes.io/name: api-1
    deployTimestamp: '1751286504'
```