### PR TITLE
feat: add HTTPRoute resource for Gateway API

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ helm delete --namespace test my-application
 | ingress.annotations | object | `nil` | Annotations for ingress. |
 | ingress.tls | list | `nil` | TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret. |
 
+### HTTPRoute Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| httpRoute.enabled | bool | `false` | Enable HTTPRoute (Gateway API). |
+| httpRoute.gatewayName | string | `"my-gateway"` | Name of the Gateway to attach this HTTPRoute to. |
+| httpRoute.gatewayNamespace | string | `""` | Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute. |
+| httpRoute.hostnames | list | `["chart-example.local"]` | Hostnames for the HTTPRoute. |
+| httpRoute.additionalLabels | object | `{}` | Additional labels for HTTPRoute. |
+| httpRoute.annotations | object | `{}` | Annotations for HTTPRoute. |
+| httpRoute.rules | list | `[{"backendRefs":[{"name":"http","port":8080}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. |
+
 ### Route Parameters
 
 | Key | Type | Default | Description |

--- a/application/templates/httproute.yaml
+++ b/application/templates/httproute.yaml
@@ -1,0 +1,30 @@
+{{- if and (.Values.httpRoute).enabled -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") }}
+  {{- fail "There is no APIGateway resource definition in the target cluster!" }}
+{{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "application.name" . }}
+  namespace: {{ include "application.namespace" . }}
+  labels:
+  {{- include "application.labels" $ | nindent 4 }}
+{{- if .Values.httpRoute.additionalLabels }}
+{{ toYaml .Values.httpRoute.additionalLabels | nindent 4 }}
+{{- end }}
+{{- if .Values.httpRoute.annotations }}
+  annotations:
+{{- toYaml .Values.httpRoute.annotations | nindent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.gatewayName | default "my-gateway" }}
+      {{- if .Values.httpRoute.gatewayNamespace }}
+      namespace: {{ .Values.httpRoute.gatewayNamespace }}
+      {{- end }}
+  hostnames:
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+  rules:
+    {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+{{- end }}

--- a/application/tests/httproute_test.yaml
+++ b/application/tests/httproute_test.yaml
@@ -1,0 +1,237 @@
+suite: APIGateway-HTTPRoute
+
+templates:
+  - httproute.yaml
+
+tests:
+  - it: does not render when httpRoute is not enabled
+    set:
+      httpRoute:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when Gateway API is not available
+    set:
+      httpRoute:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "There is no APIGateway resource definition in the target cluster!"
+
+  - it: renders a basic HTTPRoute with minimal configuration
+    set:
+      applicationName: "my-app"
+      httpRoute:
+        enabled: true
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: metadata.name
+          value: my-app
+      - equal:
+          path: spec.hostnames[0]
+          value: example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: example-service
+
+  - it: renders HTTPRoute with additional labels
+    set:
+      httpRoute:
+        enabled: true
+        additionalLabels:
+          custom: label
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: metadata.labels.custom
+          value: label
+
+  - it: renders HTTPRoute with annotations
+    set:
+      httpRoute:
+        enabled: true
+        annotations:
+          custom: annotation
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: metadata.annotations.custom
+          value: annotation
+
+  - it: renders HTTPRoute with custom gatewayName and gatewayNamespace
+    set:
+      httpRoute:
+        enabled: true
+        gatewayName: custom-gateway
+        gatewayNamespace: custom-ns
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: custom-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: custom-ns
+
+  - it: renders HTTPRoute with multiple hostnames
+    set:
+      httpRoute:
+        enabled: true
+        hostnames:
+          - example.com
+          - another-example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: example.com
+      - equal:
+          path: spec.hostnames[1]
+          value: another-example.com
+
+  - it: renders HTTPRoute with multiple rules
+    set:
+      httpRoute:
+        enabled: true
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 80
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /api
+            backendRefs:
+              - name: api-service
+                port: 8080
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /api
+      - equal:
+          path: spec.rules[1].backendRefs[0].name
+          value: api-service
+  - it: renders HTTPRoute with a request redirect filter
+    set:
+      applicationName: "tls-redirect"
+      httpRoute:
+        enabled: true
+        gatewayName: example-gateway
+        hostnames:
+          - foo.example.com
+          - bar.example.com
+        rules:
+          - filters:
+              - type: RequestRedirect
+                requestRedirect:
+                  scheme: https
+                  port: 443
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: metadata.name
+          value: tls-redirect
+      - equal:
+          path: spec.parentRefs[0].name
+          value: example-gateway
+      - equal:
+          path: spec.hostnames[0]
+          value: foo.example.com
+      - equal:
+          path: spec.hostnames[1]
+          value: bar.example.com
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: https
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.port
+          value: 443

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -570,6 +570,38 @@ ingress:
     #   hosts:
     #     - chart-example.local
 
+httpRoute:
+  # -- (bool) Enable HTTPRoute (Gateway API).
+  # @section -- HTTPRoute Parameters
+  enabled: false
+  # -- (string) Name of the Gateway to attach this HTTPRoute to.
+  # @section -- HTTPRoute Parameters
+  gatewayName: my-gateway
+  # -- (string) Namespace of the Gateway to attach this HTTPRoute to.
+  # If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute.
+  # @section -- HTTPRoute Parameters
+  gatewayNamespace: ""
+  # -- (list) Hostnames for the HTTPRoute.
+  # @section -- HTTPRoute Parameters
+  hostnames:
+    - "chart-example.local"
+  # -- (object) Additional labels for HTTPRoute.
+  # @section -- HTTPRoute Parameters
+  additionalLabels: {}
+  # -- (object) Annotations for HTTPRoute.
+  # @section -- HTTPRoute Parameters
+  annotations: {}
+  # -- (list) Rules for HTTPRoute.
+  # @section -- HTTPRoute Parameters
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: http
+          port: 8080
+
 route:
   # -- (bool) Deploy a Route (OpenShift) resource.
   # @section -- Route Parameters


### PR DESCRIPTION
Hi,
I'm trying to add support for the HTTPRoute resource to be able to use Gateway API

https://kubernetes.io/docs/concepts/services-networking/gateway/#api-kind-httproute