### PR TITLE
fix(backup): move includedNamespaces out of range and guard for nil

### DIFF
--- a/application/templates/backup.yaml
+++ b/application/templates/backup.yaml
@@ -17,9 +17,11 @@ spec:
   labelSelector:
     matchLabels:
        app.kubernetes.io/part-of: {{ include "application.name" . }}
-  {{- range $namespace := .Values.backup.includedNamespaces }}
+  {{- if not (kindIs "invalid" .Values.backup.includedNamespaces) }}
   includedNamespaces:
-  - {{ include "application.tplvalues.render" ( dict "value" $namespace "context" $ ) }}
+    {{- range $namespace := .Values.backup.includedNamespaces }}
+    - {{ include "application.tplvalues.render" ( dict "value" $namespace "context" $ ) }}
+    {{- end }}
   {{- end }}
   defaultVolumesToRestic: {{  .Values.backup.defaultVolumesToRestic }}
   snapshotVolumes: {{ .Values.backup.snapshotVolumes }}


### PR DESCRIPTION
The includedNamespaces key was previously placed inside the range
loop, which caused two issues:

- If .Values.backup.includedNamespaces was nil, Helm errored
- If multiple namespaces were set, the key was repeated for each
  item, producing invalid YAML

This change moves includedNamespaces outside the loop and adds a
kindIs "invalid" guard. This prevents errors on nil and renders a
valid list when multiple namespaces are provided.
