### PR TITLE
feat!: drop default part-of label, require explicit override

### DIFF
--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -63,9 +63,6 @@ app.kubernetes.io/component: {{ .Values.componentOverride }}
 {{- end }}
 {{- if .Values.partOfOverride }}
 app.kubernetes.io/part-of: {{ .Values.partOfOverride }}
-{{- /* TODO: obsolete else case on major bump (?) */}}
-{{- else }}
-app.kubernetes.io/part-of: {{ include "application.name" . }}
 {{- end }}
 {{- include "application.additionalLabels" . }}
 {{- end }}

--- a/application/tests/common_test.yaml
+++ b/application/tests/common_test.yaml
@@ -75,9 +75,6 @@ tests:
           value: image-tag
       - notExists:
           path: metadata.labels["app.kubernetes.io/component"]
-      - equal:
-          path: metadata.labels["app.kubernetes.io/part-of"]
-          value: application
 
   - it: Common labels
     documentSelector:


### PR DESCRIPTION
## Summary

- Remove the default `app.kubernetes.io/part-of` label that was automatically set to the release name
- The label is now only rendered when `partOfOverride` is explicitly set

## Breaking change

**The `app.kubernetes.io/part-of` label is no longer added to resources by default.**

Previously, every resource rendered by this chart included `app.kubernetes.io/part-of: <release-name>` automatically. This label is now opt-in only.

If you rely on this label (for example in label selectors, network policies, or monitoring queries), you must explicitly set it:

```yaml
partOfOverride: my-application
```

If you do not use this label, no action is required.

## Test plan

- [x] Helm unit tests updated to reflect removed default