### PR TITLE
feat!: prefix all resource names with release name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ helm delete --namespace test my-application
 | namespaceOverride | string | `""` | Override the namespace for all resources. |
 | componentOverride | string | `""` | Override the component label for all resources. |
 | partOfOverride | string | `""` | Override the partOf label for all resources. |
-| applicationName | string | `{{ .Chart.Name }}` | Application name. |
+| applicationName | string | `{{ .Release.Name }}` | Application name. Used as a prefix for all resource names. |
 | additionalLabels | tpl/object | `nil` | Additional labels for all resources. |
 | extraObjects | [list or object] of [tpl/object or tpl/string] | `nil` | Extra K8s manifests to deploy. Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are passed through tpl to render. |
 

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 Define the name of the chart/application.
 */}}
 {{- define "application.name" -}}
-{{- default .Chart.Name .Values.applicationName | trunc 63 | trimSuffix "-" -}}
+{{- default .Release.Name .Values.applicationName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/application/templates/backup.yaml
+++ b/application/templates/backup.yaml
@@ -2,7 +2,7 @@
 apiVersion: velero.io/v1
 kind: Backup
 metadata:
-  name: {{ printf "%s-backup" (include "application.name" .) | trunc 63 | quote }}
+  name: {{ printf "%s-%s" (include "application.name" .) "backup" | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Values.backup.namespace | default ( include "application.namespace" . ) | quote }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/backup.yaml
+++ b/application/templates/backup.yaml
@@ -2,7 +2,7 @@
 apiVersion: velero.io/v1
 kind: Backup
 metadata:
-  name: {{ printf "%s-backup" .Values.applicationName | trunc 63 | quote }}
+  name: {{ printf "%s-backup" (include "application.name" .) | trunc 63 | quote }}
   namespace: {{ .Values.backup.namespace | default ( include "application.namespace" . ) | quote }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/certificate.yaml
+++ b/application/templates/certificate.yaml
@@ -3,7 +3,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ template "application.name" . }}-certificate
+  name: {{ printf "%s-%s" (include "application.name" .) "certificate" | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/clusterrole.yaml
+++ b/application/templates/clusterrole.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "application.name" $ }}-cr-{{ .name }}
+  name: {{ printf "%s-%s" (include "application.name" $) .name | trunc 63 | trimSuffix "-" }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}
 {{- if $.Values.rbac.additionalLabels }}

--- a/application/templates/clusterrolebinding.yaml
+++ b/application/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "application.name" $ }}-crb-{{ .name }}
+  name: {{ printf "%s-%s" (include "application.name" $) .name | trunc 63 | trimSuffix "-" }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}
 {{- if $.Values.rbac.additionalLabels }}
@@ -17,7 +17,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "application.name" $ }}-cr-{{ .name }}
+  name: {{ printf "%s-%s" (include "application.name" $) .name | trunc 63 | trimSuffix "-" }}
 subjects:
   - kind: ServiceAccount
   {{- if $.Values.rbac.serviceAccount.name }}

--- a/application/templates/configmap.yaml
+++ b/application/templates/configmap.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+  name: {{ printf "%s-%s" (include "application.name" $) $nameSuffix | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
 {{- end }}
-  name: {{ $name }}
+  name: {{ printf "%s-%s" (include "application.name" $) $name | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "application.namespace" $ }}
 spec:
   schedule: {{ $job.schedule | quote }}

--- a/application/templates/externalsecrets.yaml
+++ b/application/templates/externalsecrets.yaml
@@ -8,7 +8,7 @@ apiVersion: external-secrets.io/v1beta1
 {{- end }}
 kind: ExternalSecret
 metadata:
-  name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+  name: {{ printf "%s-%s" (include "application.name" $) $nameSuffix | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}
@@ -40,7 +40,7 @@ spec:
     name: {{ default $.Values.externalSecret.secretStore.name ($data.secretStore).name }}
     kind: {{ default $.Values.externalSecret.secretStore.kind ($data.secretStore).kind }}
   target:
-    name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+    name: {{ printf "%s-%s" (include "application.name" $) $nameSuffix | trunc 63 | trimSuffix "-" }}
     template:
 {{- if ($data.target).template }}
 {{  include "application.tplvalues.render" ( dict "value" ($data.target).template "context" $ ) | indent 8 }}

--- a/application/templates/grafanadashboard.yaml
+++ b/application/templates/grafanadashboard.yaml
@@ -4,7 +4,7 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: {{ $name }}
+  name: {{ printf "%s-%s" (include "application.name" $) $name | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "application.namespace" $ }}
   labels:
     # this label is used as dashboard selector by grafana operator

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
 {{- end }}
-  name: {{ $name }}
+  name: {{ printf "%s-%s" (include "application.name" $) $name | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "application.namespace" $ }}
 spec:
   {{- if not (kindIs "invalid" $job.startingDeadlineSeconds) }}

--- a/application/templates/pvc.yaml
+++ b/application/templates/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 {{- if .Values.persistence.name }}
   name: "{{ .Values.persistence.name }}"
 {{- else }}
-  name: {{ template "application.name" . }}-data
+  name: {{ printf "%s-%s" (include "application.name" .) "data" | trunc 63 | trimSuffix "-" }}
 {{- end }}
   namespace: {{ include "application.namespace" . }}
   labels:

--- a/application/templates/role.yaml
+++ b/application/templates/role.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "application.name" $ }}-role-{{ .name }}
+  name: {{ printf "%s-%s" (include "application.name" $) .name | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/rolebinding.yaml
+++ b/application/templates/rolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "application.name" $ }}-rolebinding-{{ .name }}
+  name: {{ printf "%s-%s" (include "application.name" $) .name | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}
@@ -18,7 +18,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "application.name" $ }}-role-{{ .name }}
+  name: {{ printf "%s-%s" (include "application.name" $) .name | trunc 63 | trimSuffix "-" }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "application.serviceAccountName" $ }}

--- a/application/templates/sealedsecrets.yaml
+++ b/application/templates/sealedsecrets.yaml
@@ -4,7 +4,7 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+  name: {{ printf "%s-%s" (include "application.name" $) $nameSuffix | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}
@@ -34,7 +34,7 @@ spec:
   template:
     type: {{ $config.type | default "Opaque" }}
     metadata:
-      name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+      name: {{ printf "%s-%s" (include "application.name" $) $nameSuffix | trunc 63 | trimSuffix "-" }}
       namespace: {{ template "application.namespace" $ }}
       {{- if or ($.Values.sealedSecret.annotations) ($config.annotations) ($config.clusterWide) }}
       annotations:

--- a/application/templates/secret.yaml
+++ b/application/templates/secret.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "application.name" $ }}-{{ $nameSuffix }}
+  name: {{ printf "%s-%s" (include "application.name" $) $nameSuffix | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "application.namespace" $ }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/secretproviderclass.yaml
+++ b/application/templates/secretproviderclass.yaml
@@ -3,7 +3,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
-  name: {{ .Values.secretProviderClass.name }}
+  name: {{ printf "%s-%s" (include "application.name" .) .Values.secretProviderClass.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/servicemonitor.yaml
+++ b/application/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: "monitoring.coreos.com/v1"
 kind: ServiceMonitor
 metadata:
-  name: {{ printf "%s-%s" (include "application.name" .) "monitor" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "application.name" . }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/templates/servicemonitor.yaml
+++ b/application/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: "monitoring.coreos.com/v1"
 kind: ServiceMonitor
 metadata:
-  name: {{ template "application.name" . }}-svc-monitor
+  name: {{ printf "%s-%s" (include "application.name" .) "monitor" | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "application.namespace" . }}
   labels:
   {{- include "application.labels" $ | nindent 4 }}

--- a/application/tests/clusterrole_test.yaml
+++ b/application/tests/clusterrole_test.yaml
@@ -48,7 +48,7 @@ tests:
           of: ClusterRole
       - equal:
           path: metadata.name
-          value: my-app-cr-example
+          value: my-app-example
       - equal:
           path: rules[0].apiGroups[0]
           value: "*"

--- a/application/tests/clusterrolebinding_test.yaml
+++ b/application/tests/clusterrolebinding_test.yaml
@@ -46,10 +46,10 @@ tests:
           of: ClusterRoleBinding
       - equal:
           path: metadata.name
-          value: my-app-crb-example
+          value: my-app-example
       - equal:
           path: roleRef.name
-          value: my-app-cr-example
+          value: my-app-example
       - equal:
           path: roleRef.kind
           value: ClusterRole

--- a/application/tests/common_test.yaml
+++ b/application/tests/common_test.yaml
@@ -54,6 +54,14 @@ x-keys:
     skipEmptyTemplates: true
 
 tests:
+  - it: Resource names
+    documentSelector:
+      <<: *x-documentSelector
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^RELEASE-NAME(?:-.+)?$
+
   - it: Default common labels
     documentSelector:
       <<: *x-documentSelector

--- a/application/tests/common_test.yaml
+++ b/application/tests/common_test.yaml
@@ -54,13 +54,33 @@ x-keys:
     skipEmptyTemplates: true
 
 tests:
-  - it: Resource names
-    documentSelector:
-      <<: *x-documentSelector
+  - it: should render valid resource names using default release name
+    set:
+      applicationName: ""
     asserts:
       - matchRegex:
           path: metadata.name
           pattern: ^RELEASE-NAME(?:-.+)?$
+
+  - it: should render valid resource names using actual release name
+    set:
+      applicationName: ""
+    release:
+      name: myapp
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^myapp(?:-.+)?$
+
+  - it: should render valid resource names when applicationName is set
+    set:
+      applicationName: myapp
+    release:
+      name: whatever
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^myapp(?:-.+)?$
 
   - it: Default common labels
     documentSelector:

--- a/application/tests/common_test.yaml
+++ b/application/tests/common_test.yaml
@@ -57,6 +57,8 @@ tests:
   - it: should render valid resource names using default release name
     set:
       applicationName: ""
+    documentSelector:
+      <<: *x-documentSelector
     asserts:
       - matchRegex:
           path: metadata.name
@@ -67,6 +69,8 @@ tests:
       applicationName: ""
     release:
       name: myapp
+    documentSelector:
+      <<: *x-documentSelector
     asserts:
       - matchRegex:
           path: metadata.name
@@ -75,8 +79,11 @@ tests:
   - it: should render valid resource names when applicationName is set
     set:
       applicationName: myapp
+      extraObjects: []
     release:
       name: whatever
+    documentSelector:
+      <<: *x-documentSelector
     asserts:
       - matchRegex:
           path: metadata.name

--- a/application/tests/grafanadashboard_test.yaml
+++ b/application/tests/grafanadashboard_test.yaml
@@ -47,7 +47,7 @@ tests:
           of: GrafanaDashboard
       - equal:
           path: metadata.name
-          value: example-dashboard
+          value: RELEASE-NAME-example-dashboard
       - equal:
           path: spec.json.title
           value: "Example Dashboard"

--- a/application/tests/role_test.yaml
+++ b/application/tests/role_test.yaml
@@ -40,7 +40,7 @@ tests:
           of: Role
       - equal:
           path: metadata.name
-          value: my-app-role-example
+          value: my-app-example
       - equal:
           path: rules[0].apiGroups[0]
           value: "*"

--- a/application/tests/rolebinding_test.yaml
+++ b/application/tests/rolebinding_test.yaml
@@ -36,10 +36,10 @@ tests:
           of: RoleBinding
       - equal:
           path: metadata.name
-          value: my-app-rolebinding-example
+          value: my-app-example
       - equal:
           path: roleRef.name
-          value: my-app-role-example
+          value: my-app-example
 
   - it: includes correct namespace
     set:

--- a/application/tests/secretproviderclass_test.yaml
+++ b/application/tests/secretproviderclass_test.yaml
@@ -40,7 +40,7 @@ tests:
           of: SecretProviderClass
       - equal:
           path: metadata.name
-          value: example-secret-provider
+          value: RELEASE-NAME-example-secret-provider
       - equal:
           path: spec.provider
           value: azure

--- a/application/tests/servicemonitor_test.yaml
+++ b/application/tests/servicemonitor_test.yaml
@@ -41,7 +41,7 @@ tests:
           of: ServiceMonitor
       - equal:
           path: metadata.name
-          value: my-app-svc-monitor
+          value: my-app-monitor
       - equal:
           path: spec.endpoints[0].port
           value: http

--- a/application/tests/servicemonitor_test.yaml
+++ b/application/tests/servicemonitor_test.yaml
@@ -41,7 +41,7 @@ tests:
           of: ServiceMonitor
       - equal:
           path: metadata.name
-          value: my-app-monitor
+          value: my-app
       - equal:
           path: spec.endpoints[0].port
           value: http

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -10,8 +10,8 @@ componentOverride: ""
 # @section -- Parameters
 partOfOverride: ""
 
-# -- (string) Application name.
-# @default -- `{{ .Chart.Name }}`
+# -- (string) Application name. Used as a prefix for all resource names.
+# @default -- `{{ .Release.Name }}`
 # @section -- Parameters
 applicationName: ""
 


### PR DESCRIPTION
fixes #446

## BREAKING CHANGE

All resource names now include the release name as a prefix and use a consistent `printf | trunc 63 | trimSuffix "-"` generation pattern.

The `application.name` helper now defaults to `.Release.Name` instead of `.Chart.Name` when `applicationName` is not set.

### ⚠️ PVC name change — risk of data loss

If `applicationName` was not set, the PVC name changes from `<chartName>-data` to `<releaseName>-data`. This will create a **new PVC** and orphan the existing one, causing data loss.

**To prevent drift**, set `persistence.name` to your current PVC name before upgrading:

```yaml
persistence:
  name: <your-current-pvc-name>
```

### Resources now prefixed with release/application name

- CronJob: `<jobKey>` → `<name>-<jobKey>`
- Job: `<jobKey>` → `<name>-<jobKey>`
- GrafanaDashboard: `<dashboardKey>` → `<name>-<dashboardKey>`
- SecretProviderClass: `<spcName>` → `<name>-<spcName>`
- Backup: used `applicationName` directly → uses `application.name` helper (falls back to release name when empty)

### Redundant type suffixes removed

- ClusterRole: `<name>-cr-<role>` → `<name>-<role>`
- ClusterRoleBinding: `<name>-crb-<role>` → `<name>-<role>`
- Role: `<name>-role-<role>` → `<name>-<role>`
- RoleBinding: `<name>-rolebinding-<role>` → `<name>-<role>`
- ServiceMonitor: `<name>-svc-monitor` → `<name>`

### Default name fallback changed

All resources: default name changes from chart name to release name when `applicationName` is empty.

The `applicationName` value description has been updated to reflect its role as a prefix for all resource names, with the new default of `{{ .Release.Name }}`.