### PR TITLE
feat!: add pod security context support to CronJob and Job

### DIFF
--- a/application/ci/values.yaml
+++ b/application/ci/values.yaml
@@ -429,6 +429,16 @@ cronJob:
         limits:
           memory: 512Mi
           cpu: 500m
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -472,6 +482,16 @@ job:
         limits:
           memory: 512Mi
           cpu: 500m
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -135,7 +135,7 @@ spec:
             volumeMounts:
 {{ toYaml . | indent 12 }}
             {{- end }}
-            {{- with $job.securityContext }}
+            {{- with $job.containerSecurityContext }}
             securityContext:
               {{- toYaml . | nindent 14 }}
             {{- end }}
@@ -163,6 +163,10 @@ spec:
           {{- end }}
           {{- with $job.imagePullSecrets }}
           imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $job.securityContext }}
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if $job.dnsConfig }}

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -111,6 +111,9 @@ spec:
         resources:
 {{ toYaml . | indent 10 }}
         {{- end }}
+        {{- with $job.containerSecurityContext }}
+        securityContext: {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- with $job.volumeMounts }}
         volumeMounts:
 {{ toYaml . | indent 8 }}

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -112,7 +112,8 @@ spec:
 {{ toYaml . | indent 10 }}
         {{- end }}
         {{- with $job.containerSecurityContext }}
-        securityContext: {{ toYaml . | nindent 10 }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with $job.volumeMounts }}
         volumeMounts:

--- a/application/tests/cronjob_test.yaml
+++ b/application/tests/cronjob_test.yaml
@@ -398,6 +398,44 @@ tests:
           path: spec.jobTemplate.spec.template.spec.serviceAccountName
           value: example-app
 
+  - it: does not include container security context by default
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext
+
+  - it: enable container security context when configured
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            containerSecurityContext:
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              capabilities:
+              drop:
+                - ALL
+            image:
+              repository: example-image
+              tag: example-tag
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+            drop:
+              - ALL
+
   - it: configures automount service account token by default
     set:
       cronJob:
@@ -426,6 +464,55 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
           value: true
+
+  - it: disable automount service account token when configured
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            automountServiceAccountToken: false
+            image:
+              repository: example-image
+              tag: example-tag
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: does not include pod security context by default
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+
+  - it: enable pod security context when configured
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+            securityContext:
+              fsGroup: 20000
+              seccompProfile:
+                type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+          value:
+            fsGroup: 20000
+            seccompProfile:
+              type: RuntimeDefault
 
   - it: does not include enable service links by default
     set:
@@ -582,4 +669,3 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].envFrom[0].secretRef.optional
           value: true
-

--- a/application/tests/cronjob_test.yaml
+++ b/application/tests/cronjob_test.yaml
@@ -421,8 +421,8 @@ tests:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               capabilities:
-              drop:
-                - ALL
+                drop:
+                  - ALL
             image:
               repository: example-image
               tag: example-tag
@@ -433,8 +433,8 @@ tests:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             capabilities:
-            drop:
-              - ALL
+              drop:
+                - ALL
 
   - it: configures automount service account token by default
     set:
@@ -464,21 +464,6 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
           value: true
-
-  - it: disable automount service account token when configured
-    set:
-      cronJob:
-        enabled: true
-        jobs:
-          example:
-            automountServiceAccountToken: false
-            image:
-              repository: example-image
-              tag: example-tag
-    asserts:
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
-          value: false
 
   - it: does not include pod security context by default
     set:

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -394,6 +394,44 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: example-app
 
+  - it: does not include container security context by default
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: enable container security context when configured
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            containerSecurityContext:
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              capabilities:
+              drop:
+                - ALL
+            image:
+              repository: example-image
+              tag: example-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+            drop:
+              - ALL
+
   - it: configures automount service account token by default
     set:
       job:
@@ -422,6 +460,55 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: true
+
+  - it: disable automount service account token when configured
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            automountServiceAccountToken: false
+            image:
+              repository: example-image
+              tag: example-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: does not include pod security context by default
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: enable pod security context when configured
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-image
+              tag: example-tag
+            securityContext:
+              fsGroup: 20000
+              seccompProfile:
+                type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            fsGroup: 20000
+            seccompProfile:
+              type: RuntimeDefault
 
   - it: does not include enable service links by default
     set:
@@ -573,4 +660,3 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].envFrom[0].secretRef.optional
           value: true
-

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -417,8 +417,8 @@ tests:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               capabilities:
-              drop:
-                - ALL
+                drop:
+                  - ALL
             image:
               repository: example-image
               tag: example-tag
@@ -429,8 +429,8 @@ tests:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             capabilities:
-            drop:
-              - ALL
+              drop:
+                - ALL
 
   - it: configures automount service account token by default
     set:
@@ -460,21 +460,6 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: true
-
-  - it: disable automount service account token when configured
-    set:
-      job:
-        enabled: true
-        jobs:
-          example:
-            automountServiceAccountToken: false
-            image:
-              repository: example-image
-              tag: example-tag
-    asserts:
-      - equal:
-          path: spec.template.spec.automountServiceAccountToken
-          value: false
 
   - it: does not include pod security context by default
     set:


### PR DESCRIPTION
## Summary

Add pod-level `securityContext` support to CronJob and Job templates, and rename the existing container-level security context key from `securityContext` to `containerSecurityContext` for consistency with the Deployment template.

Closes #497

## Breaking change

**CronJob users who set `securityContext` at the job level must rename it to `containerSecurityContext`.**

Previously, `cronJob.jobs.<name>.securityContext` mapped to the **container-level** `securityContext`. This PR renames that key to `containerSecurityContext` (matching the existing Deployment convention) and repurposes `securityContext` for the **pod-level** security context.

If you currently have:

```yaml
cronJob:
  jobs:
    example:
      securityContext:           # container-level (old)
        runAsNonRoot: true
```

You must migrate to:

```yaml
cronJob:
  jobs:
    example:
      containerSecurityContext:  # container-level (new)
        runAsNonRoot: true
      securityContext:           # pod-level (new, optional)
        fsGroup: 20000
```

Job templates were not previously exposing `securityContext` in templates, so the new `containerSecurityContext` key is purely additive for Jobs.

## Changes

- **cronjob.yaml**: rename container security context key from `securityContext` to `containerSecurityContext`, add pod-level `securityContext` block
- **job.yaml**: add `containerSecurityContext` (container-level) support
- **tests**: add test cases for both pod and container security contexts on CronJob and Job