### PR TITLE
feat: allow to set Pod securityContext in CronJobs

### DIFF
--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -68,6 +68,9 @@ spec:
           serviceAccountName: {{ template "application.name" $ }}
           {{- end }}
           {{- end }}
+          {{- with $job.podSecurityContext }}
+          securityContext: {{ toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $job.initContainers }}
           initContainers:
           {{- range $key, $value := . }}

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -51,6 +51,8 @@ cronJob:
     #     requests:
     #         memory: 5Gi
     #         cpu: 1
+    #   podSecurityContext:
+    #     fsGroup: 2222
     #   initContainers:
     #     init-something:
     #       image: busybox


### PR DESCRIPTION
securityContext can be defined at Pod and Container levels. This PR allows to set it up at Pod level for a given CronJob.

More details in the following links:
* https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context
* https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1