### PR TITLE
ci: replace python3 YAML check with yamllint and fix template lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,7 +151,11 @@ jobs:
           cat rendered.yaml
 
       - name: Validate YAML syntax
-        run: python3 -c "import yaml, sys; list(yaml.safe_load_all(open('rendered.yaml')))"
+        uses: frenck/action-yamllint@34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47 # v1.5.0
+        with:
+          path: rendered.yaml
+          strict: true
+          warnings: false
 
   checkov:
     name: Checkov security scan

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  indentation:
+    indent-sequences: whatever
+  line-length: disable

--- a/application/templates/alertmanagerconfig.yaml
+++ b/application/templates/alertmanagerconfig.yaml
@@ -10,14 +10,15 @@ metadata:
 {{ toYaml .Values.alertmanagerConfig.selectionLabels | indent 4 }}
 spec:
 {{- if .Values.alertmanagerConfig.spec.route }}
-    route:
-{{ toYaml .Values.alertmanagerConfig.spec.route | indent 6 }}
+  route:
+    {{- toYaml .Values.alertmanagerConfig.spec.route | nindent 4 }}
 {{- end -}}
 {{- if .Values.alertmanagerConfig.spec.receivers }}
-    receivers:
-{{ toYaml .Values.alertmanagerConfig.spec.receivers | indent 6 }}
+  receivers:
+    {{- toYaml .Values.alertmanagerConfig.spec.receivers | nindent 4 }}
 {{- end -}}
 {{- if .Values.alertmanagerConfig.spec.inhibitRules }}
-    inhibitRules: {{ toYaml .Values.alertmanagerConfig.spec.inhibitRules | nindent 6 }}
+  inhibitRules:
+    {{- toYaml .Values.alertmanagerConfig.spec.inhibitRules | nindent 4 }}
 {{- end -}}
 {{- end -}}

--- a/application/templates/backup.yaml
+++ b/application/templates/backup.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   labelSelector:
     matchLabels:
-       app.kubernetes.io/part-of: {{ include "application.name" . }}
+      app.kubernetes.io/part-of: {{ include "application.name" . }}
   {{- if not (kindIs "invalid" .Values.backup.includedNamespaces) }}
   includedNamespaces:
     {{- range $namespace := .Values.backup.includedNamespaces }}

--- a/application/templates/certificate.yaml
+++ b/application/templates/certificate.yaml
@@ -20,8 +20,10 @@ spec:
   secretName: {{ include "application.tplvalues.render" ( dict "value" .Values.certificate.secretName "context" $ ) }}
   duration: {{ .Values.certificate.duration }}
   renewBefore: {{ .Values.certificate.renewBefore }}
+  {{- with .Values.certificate.subject }}
   subject:
-{{ include "application.tplvalues.render" ( dict "value" .Values.certificate.subject "context" $ ) | indent 4 }}
+    {{- include "application.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
+  {{- end }}
   commonName: {{ include "application.tplvalues.render" ( dict "value" .Values.certificate.commonName "context" $ )  }}
  {{- if .Values.certificate.isCA }}
   isCA: {{ .Values.certificate.isCA }}
@@ -29,8 +31,10 @@ spec:
   usages:
 {{ toYaml .Values.certificate.usages | indent 4 }}
   # At least one of a DNS Name, URI, or IP address is required.
+  {{- with .Values.certificate.dnsNames }}
   dnsNames:
-{{ include "application.tplvalues.render" ( dict "value" .Values.certificate.dnsNames "context" $ ) | indent 4 }}
+    {{- include "application.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
+  {{- end }}
 {{- if .Values.certificate.ipAddresses }}
   ipAddresses:
 {{ toYaml .Values.certificate.ipAddresses | indent 4 }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -14,7 +14,8 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- with $job.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
 {{- end }}
   name: {{ $name }}
   namespace: {{ template "application.namespace" $ }}
@@ -57,7 +58,8 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with $job.additionalPodAnnotations }}
-          annotations: {{ toYaml . | nindent 12 }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         spec:
           automountServiceAccountToken: {{ kindIs "invalid" $job.automountServiceAccountToken | ternary true $job.automountServiceAccountToken }}
@@ -117,7 +119,8 @@ spec:
 {{ toYaml . | indent 12 }}
             {{- end }}
             {{- with $job.securityContext }}
-            securityContext: {{ toYaml . | nindent 14 }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
             {{- end }}
           {{- with $job.nodeSelector }}
           nodeSelector:
@@ -138,16 +141,16 @@ spec:
           {{- end }}
           {{- if $job.restartPolicy }}
           restartPolicy: {{ $job.restartPolicy }}
-          {{ else }}
+          {{- else }}
           restartPolicy: OnFailure
-          {{ end }}
+          {{- end }}
           {{- with $job.imagePullSecrets }}
           imagePullSecrets:
-{{ toYaml . | indent 12 }}
-          {{ end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if $job.dnsConfig }}
           dnsConfig:
-{{ toYaml $job.dnsConfig | indent 12 }}
+            {{- toYaml $job.dnsConfig | nindent 12 }}
           {{- end }}
           {{- if $job.dnsPolicy }}
           dnsPolicy: {{ $job.dnsPolicy }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -98,11 +98,11 @@ spec:
       {{- end }}
       {{- if .Values.deployment.tolerations }}
       tolerations:
-{{ toYaml .Values.deployment.tolerations | indent 8 -}}
+        {{- toYaml .Values.deployment.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.deployment.affinity }}
       affinity:
-{{ toYaml .Values.deployment.affinity | indent 8 -}}
+        {{- toYaml .Values.deployment.affinity | nindent 8 }}
       {{- end }}
       {{- with .Values.deployment.topologySpreadConstraints }}
       topologySpreadConstraints:
@@ -164,7 +164,7 @@ spec:
         {{- end }}
         {{- if .Values.deployment.ports }}
         ports:
-{{ toYaml .Values.deployment.ports | indent 10 }}
+          {{- toYaml .Values.deployment.ports | nindent 10 }}
         {{- end }}
         {{- if .Values.deployment.envFrom }}
         envFrom:
@@ -206,7 +206,9 @@ spec:
           periodSeconds: {{ .Values.deployment.startupProbe.periodSeconds }}
           successThreshold: {{ .Values.deployment.startupProbe.successThreshold }}
           timeoutSeconds: {{ .Values.deployment.startupProbe.timeoutSeconds }}
+          {{- if not (kindIs "invalid" .Values.deployment.startupProbe.initialDelaySeconds) }}
           initialDelaySeconds: {{ .Values.deployment.startupProbe.initialDelaySeconds }}
+          {{- end }}
           {{- if .Values.deployment.startupProbe.exec }}
           exec:
             {{- toYaml .Values.deployment.startupProbe.exec | nindent 12 }}
@@ -227,7 +229,9 @@ spec:
           periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.deployment.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
+          {{- if not (kindIs "invalid" .Values.deployment.livenessProbe.initialDelaySeconds) }}
           initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+          {{- end }}
           {{- if .Values.deployment.livenessProbe.exec }}
           exec:
             {{- toYaml .Values.deployment.livenessProbe.exec | nindent 12 }}
@@ -248,7 +252,9 @@ spec:
           periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.deployment.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
+          {{- if not (kindIs "invalid" .Values.deployment.readinessProbe.initialDelaySeconds) }}
           initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+          {{- end }}
           {{- if .Values.deployment.readinessProbe.exec }}
           exec:
             {{- toYaml .Values.deployment.readinessProbe.exec | nindent 12 }}
@@ -282,15 +288,15 @@ spec:
         {{- end }}
         {{- if .Values.deployment.containerSecurityContext }}
         securityContext:
-{{ toYaml .Values.deployment.containerSecurityContext | indent 10 }}
+          {{- toYaml .Values.deployment.containerSecurityContext | nindent 10 }}
         {{- end }}
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 6 }}
         {{- end }}
         {{- if .Values.deployment.securityContext }}
       securityContext:
-{{ toYaml .Values.deployment.securityContext | indent 8 }}
-          {{- end }}
+        {{- toYaml .Values.deployment.securityContext | nindent 8 }}
+      {{- end }}
       {{- if .Values.deployment.dnsConfig }}
       dnsConfig:
 {{ toYaml .Values.deployment.dnsConfig | indent 8 }}

--- a/application/templates/endpointmonitor.yaml
+++ b/application/templates/endpointmonitor.yaml
@@ -19,11 +19,11 @@ spec:
   urlFrom:
 {{- if and .Values.route .Values.route.enabled }}
     routeRef:
-      name:  {{ template "application.name" . }}
+      name: {{ template "application.name" . }}
 {{- end }}
 {{- if and .Values.ingress .Values.ingress.enabled }}
     ingressRef:
-      name:  {{ template "application.name" . }}
+      name: {{ template "application.name" . }}
 {{- end }}
 {{- if .Values.endpointMonitor.additionalConfig }}
 {{ toYaml .Values.endpointMonitor.additionalConfig | indent 2 }}

--- a/application/templates/externalsecrets.yaml
+++ b/application/templates/externalsecrets.yaml
@@ -33,8 +33,8 @@ spec:
 {{- end }}
 {{- if $data.dataFrom }}
   dataFrom:
-   - extract:
-{{ toYaml $data.dataFrom | indent 6  }}
+  - extract:
+{{ toYaml $data.dataFrom | indent 6 }}
 {{- end }}
   secretStoreRef:
     name: {{ default $.Values.externalSecret.secretStore.name ($data.secretStore).name }}

--- a/application/templates/hpa.yaml
+++ b/application/templates/hpa.yaml
@@ -26,7 +26,7 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+  {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
   {{- if .Values.autoscaling.behavior }}
   behavior:
     {{- toYaml .Values.autoscaling.behavior | nindent 4 }}

--- a/application/templates/ingress.yaml
+++ b/application/templates/ingress.yaml
@@ -40,6 +40,6 @@ spec:
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:
-{{ include "application.tplvalues.render" (dict "value" .Values.ingress.tls "context" $) | indent 3 }}
+    {{- include "application.tplvalues.render" (dict "value" .Values.ingress.tls "context" $) | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -14,7 +14,8 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- with $job.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
 {{- end }}
   name: {{ $name }}
   namespace: {{ template "application.namespace" $ }}
@@ -37,7 +38,8 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with $job.additionalPodAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       automountServiceAccountToken: {{ kindIs "invalid" $job.automountServiceAccountToken | ternary true $job.automountServiceAccountToken }}
@@ -111,20 +113,21 @@ spec:
       topologySpreadConstraints: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with $job.securityContext }}
-      securityContext: {{ toYaml . | nindent 8 }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if $job.restartPolicy}}
+      {{- if $job.restartPolicy }}
       restartPolicy: {{ $job.restartPolicy }}
-      {{ else }}
+      {{- else }}
       restartPolicy: OnFailure
-      {{ end }}
-      {{- with $job.imagePullSecrets}}
+      {{- end }}
+      {{- with $job.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml . | indent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $job.dnsConfig }}
       dnsConfig:
-{{ toYaml $job.dnsConfig | indent 8 }}
+        {{- toYaml $job.dnsConfig | nindent 8 }}
       {{- end }}
       {{- if $job.dnsPolicy }}
       dnsPolicy: {{ $job.dnsPolicy }}

--- a/application/templates/networkpolicy.yaml
+++ b/application/templates/networkpolicy.yaml
@@ -32,10 +32,10 @@ spec:
 {{- end }}
 {{- if .Values.networkPolicy.egress }}
   egress:
-{{ toYaml .Values.networkPolicy.egress | indent 4 }}
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
 {{- end }}
 {{- if .Values.networkPolicy.ingress }}
   ingress:
-{{ toYaml .Values.networkPolicy.ingress | indent 4 }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/application/templates/role.yaml
+++ b/application/templates/role.yaml
@@ -16,6 +16,6 @@ metadata:
 {{ toYaml $.Values.rbac.annotations | indent 4 }}
 {{- end }}
 rules:
-{{ toYaml .rules | indent 2 }}
+  {{- toYaml .rules | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/application/templates/rolebinding.yaml
+++ b/application/templates/rolebinding.yaml
@@ -21,11 +21,11 @@ roleRef:
   name: {{ template "application.name" $ }}-role-{{ .name }}
 subjects:
   - kind: ServiceAccount
-  {{- if $.Values.rbac.serviceAccount.name }}
+    {{- if $.Values.rbac.serviceAccount.name }}
     name: {{ $.Values.rbac.serviceAccount.name }}
-  {{- else }}
+    {{- else }}
     name: {{ template "application.name" $ }}
-  {{- end }}
+    {{- end }}
     namespace: {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/application/templates/sealedsecrets.yaml
+++ b/application/templates/sealedsecrets.yaml
@@ -16,10 +16,10 @@ metadata:
 {{- end }}
 {{- if or ($.Values.sealedSecret.annotations) ($config.annotations) ($config.clusterWide) }}
   annotations:
-{{- if $config.annotations }}  
+{{- if $config.annotations }}
 {{ toYaml $config.annotations | indent 4 }}
 {{- end }}
-{{- if $.Values.sealedSecret.annotations }}  
+{{- if $.Values.sealedSecret.annotations }}
 {{ toYaml $.Values.sealedSecret.annotations | indent 4 }}
 {{- end }}
 {{- if $config.clusterWide}}
@@ -38,17 +38,17 @@ spec:
       namespace: {{ template "application.namespace" $ }}
       {{- if or ($.Values.sealedSecret.annotations) ($config.annotations) ($config.clusterWide) }}
       annotations:
-      {{- if $config.annotations }}  
+      {{- if $config.annotations }}
       {{ toYaml $config.annotations | indent 2 }}
       {{- end }}
-      {{- if $.Values.sealedSecret.annotations }}  
+      {{- if $.Values.sealedSecret.annotations }}
       {{ toYaml $.Values.sealedSecret.annotations | indent 2 }}
       {{- end }}
       {{- if $config.clusterWide}}
         sealedsecrets.bitnami.com/cluster-wide: "true"
       {{- end}}
       {{- end }}
-      {{- if or ($config.labels) ($.Values.sealedSecret.additionalLabels) }}  
+      {{- if or ($config.labels) ($.Values.sealedSecret.additionalLabels) }}
       labels:
       {{- if $config.labels }}
       {{ toYaml $config.labels | indent 2 }}

--- a/application/templates/secretproviderclass.yaml
+++ b/application/templates/secretproviderclass.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .Values.secretProviderClass.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "application.labels" $ | nindent 4 }}  
+  {{- include "application.labels" $ | nindent 4 }}
 spec:
   provider: {{ .Values.secretProviderClass.provider }}
   parameters:
@@ -16,12 +16,12 @@ spec:
     roleName: {{ include "application.tplvalues.render" (dict "value" .Values.secretProviderClass.roleName "context" $) }}
     {{- if .Values.secretProviderClass.objects }}
     objects:
-    {{ toYaml .Values.secretProviderClass.objects | indent 4 }}
+      {{- toYaml .Values.secretProviderClass.objects | nindent 6 }}
     {{- end }}
   {{- if .Values.secretProviderClass.secretObjects }}
   secretObjects:
   {{- range $value := .Values.secretProviderClass.secretObjects }}
-    - data: {{- toYaml $value.data | nindent 8 }}  
+    - data: {{- toYaml $value.data | nindent 8 }}
       secretName: {{ $value.secretName }}
       type: {{ $value.type }}
   {{- end }}


### PR DESCRIPTION
## Summary

- Replace inline `python3` YAML syntax validation with [`frenck/action-yamllint`](https://github.com/frenck/action-yamllint) in the render CI job
- Add `.yamllint` config (`indent-sequences: whatever`, `line-length: disable`)
- Fix template rendering issues caught by yamllint across 14 templates:
  - **Trailing spaces**: empty values (`securityContext:`, `subject:`, `dnsNames:`), trailing whitespace in conditionals (sealedsecrets, secretproviderclass)
  - **Indentation**: inconsistent `indent`/`nindent` usage (alertmanagerconfig, hpa, deployment, job, cronjob, networkpolicy, role, rolebinding, ingress, externalsecrets, backup)
  - **Typos**: double space in endpointmonitor `name:` field
  - **Empty rendering**: `initialDelaySeconds`, `subject`, `dnsNames` now conditionally rendered to avoid trailing whitespace when unset

## yamllint config

```yaml
extends: default

rules:
  indent-sequences: whatever  # templates mix both styles via toYaml
  line-length: disable        # annotation values exceed 80 chars
```

## Test plan

- [x] `helm unittest` passes (299 tests)
- [x] yamllint passes on all 3 render matrix variants (defaults, base, crds)
- [x] CI render job passes with yamllint action