### PR TITLE
feat!: remove deprecated list-based envFrom for Jobs and CronJobs

### DIFF
--- a/application/templates/NOTES.txt
+++ b/application/templates/NOTES.txt
@@ -7,36 +7,3 @@ service.loadBalancerIP:
   Please refer to the Kubernetes documentation for more information.
 {{- end }}
 
-{{- range $name, $job := (.Values.job).jobs }}
-{{- if kindIs "slice" $job.envFrom }}
-job.jobs.{{ $name }}.envFrom:
-  Defining envFrom as a list is deprecated and will be removed in the next major version.
-  Please migrate to the dict-based format:
-
-    envFrom:
-      my-secret:
-        type: secret
-        name: my-secret-name
-      my-configmap:
-        type: configmap
-        nameSuffix: my-configmap-suffix
-
-{{- end }}
-{{- end }}
-
-{{- range $name, $job := (.Values.cronJob).jobs }}
-{{- if kindIs "slice" $job.envFrom }}
-cronJob.jobs.{{ $name }}.envFrom:
-  Defining envFrom as a list is deprecated and will be removed in the next major version.
-  Please migrate to the dict-based format:
-
-    envFrom:
-      my-secret:
-        type: secret
-        name: my-secret-name
-      my-configmap:
-        type: configmap
-        nameSuffix: my-configmap-suffix
-
-{{- end }}
-{{- end }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -101,9 +101,6 @@ spec:
             {{- end }}
             {{- if $job.envFrom }}
             envFrom:
-            {{- if kindIs "slice" $job.envFrom }}
-{{ toYaml $job.envFrom | indent 12 }}
-            {{- else }}
             {{- range $value := $job.envFrom }}
             {{- if (eq .type "configmap") }}
             - configMapRef:
@@ -126,7 +123,6 @@ spec:
                 name: {{ template "application.name" $ }}
                 {{- end }}
                 optional: {{ default false $value.optional }}
-            {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -81,9 +81,6 @@ spec:
         {{- end }}
         {{- if $job.envFrom }}
         envFrom:
-        {{- if kindIs "slice" $job.envFrom }}
-{{ toYaml $job.envFrom | indent 8 }}
-        {{- else }}
         {{- range $value := $job.envFrom }}
         {{- if (eq .type "configmap") }}
         - configMapRef:
@@ -106,7 +103,6 @@ spec:
             name: {{ template "application.name" $ }}
             {{- end }}
             optional: {{ default false $value.optional }}
-        {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/application/tests/cronjob_test.yaml
+++ b/application/tests/cronjob_test.yaml
@@ -547,25 +547,3 @@ tests:
           path: spec.jobTemplate.spec.template.spec.containers[0].envFrom[0].secretRef.optional
           value: true
 
-  - it: supports legacy list-based envFrom (vanilla form, backward compatibility)
-    set:
-      cronJob:
-        enabled: true
-        jobs:
-          example:
-            schedule: "0 * * * *"
-            image:
-              repository: example-image
-              tag: example-tag
-            envFrom:
-              - secretRef:
-                  name: my-legacy-secret
-              - configMapRef:
-                  name: my-legacy-configmap
-    asserts:
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].envFrom[0].secretRef.name
-          value: my-legacy-secret
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].envFrom[1].configMapRef.name
-          value: my-legacy-configmap

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -541,24 +541,3 @@ tests:
           path: spec.template.spec.containers[0].envFrom[0].secretRef.optional
           value: true
 
-  - it: supports legacy list-based envFrom (vanilla form, backward compatibility)
-    set:
-      job:
-        enabled: true
-        jobs:
-          example:
-            image:
-              repository: example-image
-              tag: example-tag
-            envFrom:
-              - secretRef:
-                  name: my-legacy-secret
-              - configMapRef:
-                  name: my-legacy-configmap
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
-          value: my-legacy-secret
-      - equal:
-          path: spec.template.spec.containers[0].envFrom[1].configMapRef.name
-          value: my-legacy-configmap


### PR DESCRIPTION
## Summary

- Remove deprecated list-based (slice) `envFrom` support from Job and CronJob templates
- Remove associated deprecation warnings from `NOTES.txt`
- Remove legacy backward-compatibility tests for list-based `envFrom`

## Breaking change

**The list-based `envFrom` format for Jobs and CronJobs is no longer supported. Only the dict-based format works.**

Previously, `envFrom` accepted both a raw Kubernetes list and a dict-based format. The list form was deprecated in #491 and is now removed.

If you currently use the list-based format:

```yaml
cronJob:
  jobs:
    example:
      envFrom:
        - secretRef:
            name: my-secret
        - configMapRef:
            name: my-configmap
```

You must migrate to the dict-based format:

```yaml
cronJob:
  jobs:
    example:
      envFrom:
        my-secret:
          type: secret
          name: my-secret
        my-configmap:
          type: configmap
          name: my-configmap
```

The same applies to `job.jobs.<name>.envFrom`. The Deployment template already required this format, so this change aligns Jobs and CronJobs with the existing convention.

## Test plan

- [x] All helm unit tests pass
- [ ] Verify no downstream charts rely on the list-based `envFrom` format for jobs/cronJobs