### PR TITLE
test(chart): add endpointmonitor unit tests

### DIFF
--- a/application/tests/endpointmonitor_test.yaml
+++ b/application/tests/endpointmonitor_test.yaml
@@ -1,0 +1,209 @@
+suite: EndpointMonitor
+
+templates:
+  - endpointmonitor.yaml
+
+tests:
+  - it: does not render when endpointMonitor is not enabled
+    set:
+      endpointMonitor:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when endpointMonitor API version is not available
+    set:
+      endpointMonitor:
+        enabled: true
+      ingress:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - apps/v1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when neither ingress nor route is enabled
+    set:
+      endpointMonitor:
+        enabled: true
+      ingress:
+        enabled: false
+      route:
+        enabled: false
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when ingress is enabled
+    set:
+      applicationName: my-app
+      endpointMonitor:
+        enabled: true
+      ingress:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: EndpointMonitor
+      - equal:
+          path: spec.urlFrom.ingressRef.name
+          value: my-app
+      - notExists:
+          path: spec.urlFrom.routeRef
+
+  - it: renders when route is enabled
+    set:
+      applicationName: my-app
+      endpointMonitor:
+        enabled: true
+      route:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: EndpointMonitor
+      - equal:
+          path: spec.urlFrom.routeRef.name
+          value: my-app
+      - notExists:
+          path: spec.urlFrom.ingressRef
+
+  - it: renders when both ingress and route are enabled
+    set:
+      applicationName: my-app
+      endpointMonitor:
+        enabled: true
+      ingress:
+        enabled: true
+      route:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: EndpointMonitor
+      - equal:
+          path: spec.urlFrom.routeRef.name
+          value: my-app
+      - equal:
+          path: spec.urlFrom.ingressRef.name
+          value: my-app
+
+  - it: renders correct metadata
+    set:
+      applicationName: my-app
+      endpointMonitor:
+        enabled: true
+      ingress:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - equal:
+          path: apiVersion
+          value: endpointmonitor.stakater.com/v1alpha1
+      - equal:
+          path: metadata.name
+          value: my-app
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: renders with specified namespace when namespaceOverride is set
+    set:
+      endpointMonitor:
+        enabled: true
+      ingress:
+        enabled: true
+      namespaceOverride: app-namespace
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: app-namespace
+
+  - it: renders with additional labels
+    set:
+      endpointMonitor:
+        enabled: true
+        additionalLabels:
+          custom: label
+      ingress:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - equal:
+          path: metadata.labels.custom
+          value: label
+
+  - it: renders with annotations
+    set:
+      endpointMonitor:
+        enabled: true
+        annotations:
+          custom: annotation
+      ingress:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - equal:
+          path: metadata.annotations.custom
+          value: annotation
+
+  - it: renders forceHttps in spec
+    set:
+      endpointMonitor:
+        enabled: true
+      ingress:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - equal:
+          path: spec.forceHttps
+          value: true
+
+  - it: renders with additionalConfig
+    set:
+      endpointMonitor:
+        enabled: true
+        additionalConfig:
+          healthChecker: HTTP
+          url: https://example.com
+      ingress:
+        enabled: true
+    capabilities:
+      apiVersions:
+        - endpointmonitor.stakater.com/v1alpha1
+    asserts:
+      - equal:
+          path: spec.healthChecker
+          value: HTTP
+      - equal:
+          path: spec.url
+          value: https://example.com


### PR DESCRIPTION
## Summary
- Add unit tests for EndpointMonitor template covering route, ingress and combined scenarios
- Test that EndpointMonitor is not created when neither ingress nor route is enabled
- Cover metadata, labels, annotations, namespace override, forceHttps and additionalConfig

Closes #111

## Test plan
- [x] CI helm-unittest passes for the new `endpointmonitor_test.yaml`