### PR TITLE
fix(schema): accept string for service targetPort

### DIFF
--- a/application/ci/values.yaml
+++ b/application/ci/values.yaml
@@ -249,6 +249,10 @@ service:
       name: http
       protocol: TCP
       targetPort: 8080
+    - port: 9787
+      name: metrics
+      protocol: TCP
+      targetPort: metrics
   type: ClusterIP
 
 ingress:

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -2560,7 +2560,10 @@
                   "targetPort": {
                     "default": 8080,
                     "title": "targetPort",
-                    "type": "integer"
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
                   }
                 },
                 "required": [],

--- a/mise.toml
+++ b/mise.toml
@@ -40,6 +40,7 @@ tmp="$(mktemp)"
 # helm-schema infers types too strictly from defaults:
 # - optional string fields need "null" added
 # - httpRoute port is templated then casted to int so it accepts both int and string
+# - service targetPort is IntOrString in Kubernetes
 # - extraObjects can be list or object
 jq '
   walk(
@@ -50,6 +51,7 @@ jq '
     end
   )
   | .properties.httpRoute.properties.rules.items.anyOf[].properties.backendRefs.items.anyOf[].properties.port.type = ["integer", "string", "null"]
+  | .properties.service.properties.ports.items.anyOf[].properties.targetPort.type = ["integer", "string"]
   | .properties.extraObjects.type = ["object", "array", "null"]
 ' \\
   application/values.schema.json > "$tmp"


### PR DESCRIPTION
## Summary

- Fix JSON schema to accept string values for `service.ports[].targetPort`, matching Kubernetes `IntOrString` semantics
- Add regression test in `ci/values.yaml` with `targetPort: metrics` (string named port) to catch future schema regressions
- Add helm-unittest case covering string `targetPort`

Closes #533

## Test plan

- [x] Verified CI values fail validation against old schema (`'metrics' is not of type 'integer'`)
- [x] Verified CI values pass validation against fixed schema
- [x] `helm lint` passes
- [x] All helm-unittest tests pass (361/361)