### PR TITLE
fix(schema): accept IntOrString and null for targetPort and pdb fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,8 +410,8 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | pdb.enabled | bool | `false` | Enable Pod Disruption Budget. |
-| pdb.minAvailable | int | `1` | Minimum number of pods that must be available after eviction. |
-| pdb.maxUnavailable | int | `nil` | Maximum number of unavailable pods during voluntary disruptions. |
+| pdb.minAvailable | int | `1` | Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. "25%"). |
+| pdb.maxUnavailable | int | `nil` | Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. "25%"). |
 
 ### GrafanaDashboard Parameters
 

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1963,18 +1963,23 @@
         },
         "maxUnavailable": {
           "default": "",
-          "description": "Maximum number of unavailable pods during voluntary disruptions.",
+          "description": "Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. \"25%\").",
           "title": "maxUnavailable",
           "type": [
             "integer",
+            "string",
             "null"
           ]
         },
         "minAvailable": {
           "default": 1,
-          "description": "Minimum number of pods that must be available after eviction.",
+          "description": "Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. \"25%\").",
           "title": "minAvailable",
-          "type": "integer"
+          "type": [
+            "integer",
+            "string",
+            "null"
+          ]
         }
       },
       "required": [],
@@ -2562,7 +2567,8 @@
                     "title": "targetPort",
                     "type": [
                       "integer",
-                      "string"
+                      "string",
+                      "null"
                     ]
                   }
                 },

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -1321,10 +1321,10 @@ pdb:
   # -- (bool) Enable Pod Disruption Budget.
   # @section -- PodDisruptionBudget Parameters
   enabled: false
-  # -- (int) Minimum number of pods that must be available after eviction.
+  # -- (int) Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. "25%").
   # @section -- PodDisruptionBudget Parameters
   minAvailable: 1
-  # -- (int) Maximum number of unavailable pods during voluntary disruptions.
+  # -- (int) Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. "25%").
   # @section -- PodDisruptionBudget Parameters
   maxUnavailable:
   # maxUnavailable: 1

--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ tmp="$(mktemp)"
 # helm-schema infers types too strictly from defaults:
 # - optional string fields need "null" added
 # - httpRoute port is templated then casted to int so it accepts both int and string
-# - service targetPort is IntOrString in Kubernetes
+# - service targetPort and pdb min/maxUnavailable are IntOrString in Kubernetes
 # - extraObjects can be list or object
 jq '
   walk(
@@ -51,7 +51,9 @@ jq '
     end
   )
   | .properties.httpRoute.properties.rules.items.anyOf[].properties.backendRefs.items.anyOf[].properties.port.type = ["integer", "string", "null"]
-  | .properties.service.properties.ports.items.anyOf[].properties.targetPort.type = ["integer", "string"]
+  | .properties.service.properties.ports.items.anyOf[].properties.targetPort.type = ["integer", "string", "null"]
+  | .properties.pdb.properties.minAvailable.type = ["integer", "string", "null"]
+  | .properties.pdb.properties.maxUnavailable.type = ["integer", "string", "null"]
   | .properties.extraObjects.type = ["object", "array", "null"]
 ' \\
   application/values.schema.json > "$tmp"


### PR DESCRIPTION
## Summary

- Fix JSON schema to accept null for `service.ports[].targetPort` (omitted means identity map to `port`)
- Fix JSON schema to accept string values (e.g. "25%") for `pdb.minAvailable` and `pdb.maxUnavailable`, matching Kubernetes `IntOrString` semantics
- Both pdb fields also accept null since only one of the two should be set
- Update descriptions in `values.yaml` to document percentage string support

Closes #533

## Test plan

- [x] `helm lint` passes
- [x] All helm-unittest tests pass (361/361)
- [x] Schema regeneration is idempotent (`mise run gen-schema`)