### PR TITLE
feat(schema): use comma-separated helm-docs type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,62 +56,62 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| namespaceOverride | string | `""` | Override the namespace for all resources. |
-| componentOverride | string | `""` | Override the component label for all resources. |
-| partOfOverride | string | `""` | Override the partOf label for all resources. |
-| applicationName | string | `{{ .Release.Name }}` | Application name. Used as a prefix for all resource names. |
-| additionalLabels | object | `nil` | Additional labels for all resources. Keys and values are evaluated as templates. |
-| extraObjects | list | `nil` | Extra K8s manifests to deploy. Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are evaluated as templates. |
+| namespaceOverride | string, null | `""` | Override the namespace for all resources. |
+| componentOverride | string, null | `""` | Override the component label for all resources. |
+| partOfOverride | string, null | `""` | Override the partOf label for all resources. |
+| applicationName | string, null | `{{ .Release.Name }}` | Application name. Used as a prefix for all resource names. |
+| additionalLabels | object, null | `nil` | Additional labels for all resources. Keys and values are evaluated as templates. |
+| extraObjects | list, object, null | `nil` | Extra K8s manifests to deploy. Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are evaluated as templates. |
 
 ### CronJob Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cronJob.enabled | bool | `false` | Deploy CronJob resources. |
-| cronJob.jobs | object | `nil` | Map of CronJob resources. Key will be used as a name suffix for the CronJob. Value is the CronJob configuration. See values for more details. |
+| cronJob.jobs | object, null | `nil` | Map of CronJob resources. Key will be used as a name suffix for the CronJob. Value is the CronJob configuration. See values for more details. |
 
 ### Job Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | job.enabled | bool | `false` | Deploy Job resources. |
-| job.jobs | object | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details. |
+| job.jobs | object, null | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details. |
 
 ### Deployment Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deployment.enabled | bool | `true` | Enable Deployment. |
-| deployment.additionalLabels | object | `nil` | Additional labels for Deployment. |
-| deployment.podLabels | object | `nil` | Additional pod labels which are used in Service's Label Selector. |
-| deployment.annotations | object | `nil` | Annotations for Deployment. |
-| deployment.additionalPodAnnotations | object | `nil` | Additional pod annotations. |
+| deployment.additionalLabels | object, null | `nil` | Additional labels for Deployment. |
+| deployment.podLabels | object, null | `nil` | Additional pod labels which are used in Service's Label Selector. |
+| deployment.annotations | object, null | `nil` | Annotations for Deployment. |
+| deployment.additionalPodAnnotations | object, null | `nil` | Additional pod annotations. |
 | deployment.strategy.type | string | `"RollingUpdate"` | Type of deployment strategy. |
 | deployment.reloadOnChange | bool | `true` | Reload deployment if attached Secret/ConfigMap changes. |
-| deployment.nodeSelector | object | `nil` | Select the node where the pods should be scheduled. |
+| deployment.nodeSelector | object, null | `nil` | Select the node where the pods should be scheduled. |
 | deployment.hostAliases | list | `nil` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files. |
-| deployment.initContainers | object | `nil` | Add init containers to the pods. |
-| deployment.fluentdConfigAnnotations | object | `nil` | Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>. |
+| deployment.initContainers | object, null | `nil` | Add init containers to the pods. |
+| deployment.fluentdConfigAnnotations | object, null | `nil` | Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>. |
 | deployment.replicas | int | `nil` | Number of replicas. |
 | deployment.imagePullSecrets | list | `[]` | List of secrets to be used for pulling the images. |
-| deployment.envFrom | object | `nil` | Mount environment variables from ConfigMap or Secret to the pod. Use `nameSuffix` for resources managed by this chart (name will be prefixed with application name), or `name` to reference an existing external ConfigMap or Secret not managed by this chart. See the README "Consuming environment variable in application chart" section for more details. |
-| deployment.env | object | `nil` | Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details. |
-| deployment.volumes | object | `nil` | Volumes to be added to the pod. Key is the name of the volume. Value is the volume definition. |
-| deployment.volumeMounts | object | `nil` | Mount path for Volumes. Key is the name of the volume. Value is the volume mount definition. |
-| deployment.priorityClassName | string | `""` | Define the priority class for the pod. |
-| deployment.runtimeClassName | string | `""` | Set the runtimeClassName for the deployment's pods. |
+| deployment.envFrom | object, null | `nil` | Mount environment variables from ConfigMap or Secret to the pod. Use `nameSuffix` for resources managed by this chart (name will be prefixed with application name), or `name` to reference an existing external ConfigMap or Secret not managed by this chart. See the README "Consuming environment variable in application chart" section for more details. |
+| deployment.env | object, null | `nil` | Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details. |
+| deployment.volumes | object, null | `nil` | Volumes to be added to the pod. Key is the name of the volume. Value is the volume definition. |
+| deployment.volumeMounts | object, null | `nil` | Mount path for Volumes. Key is the name of the volume. Value is the volume mount definition. |
+| deployment.priorityClassName | string, null | `""` | Define the priority class for the pod. |
+| deployment.runtimeClassName | string, null | `""` | Set the runtimeClassName for the deployment's pods. |
 | deployment.tolerations | list | `nil` | Taint tolerations for the pods. |
-| deployment.affinity | object | `nil` | Affinity for the pods. |
+| deployment.affinity | object, null | `nil` | Affinity for the pods. |
 | deployment.topologySpreadConstraints | list | `nil` | Topology spread constraints for the pods. |
 | deployment.revisionHistoryLimit | int | `2` | Number of ReplicaSet revisions to retain. |
 | deployment.image.repository | tpl | `""` | Repository. |
 | deployment.image.tag | tpl | `""` | Tag. |
 | deployment.image.digest | tpl | `""` | Image digest. If resolved to a non-empty value, digest takes precedence on the tag. |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
-| deployment.dnsConfig | object | `nil` | DNS config for the pods. |
-| deployment.dnsPolicy | string | `""` | DNS Policy. |
+| deployment.dnsConfig | object, null | `nil` | DNS config for the pods. |
+| deployment.dnsPolicy | string, null | `""` | DNS Policy. |
 | deployment.enableServiceLinks | bool | `true` | Enable Kubernetes service links. |
-| deployment.startupProbe | object | See below | Startup probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.startupProbe | object, null | See below | Startup probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.startupProbe.enabled | bool | `false` | Enable Startup probe. |
 | deployment.startupProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.startupProbe.periodSeconds | int | `10` | Time between retries. |
@@ -121,7 +121,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.startupProbe.exec | object | `{}` | Exec probe. |
 | deployment.startupProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.startupProbe.grpc | object | `{}` | gRPC probe. |
-| deployment.readinessProbe | object | See below | Readiness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.readinessProbe | object, null | See below | Readiness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.readinessProbe.enabled | bool | `false` | Enable Readiness probe. |
 | deployment.readinessProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.readinessProbe.periodSeconds | int | `10` | Time between retries. |
@@ -131,7 +131,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.readinessProbe.exec | object | `{}` | Exec probe. |
 | deployment.readinessProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.readinessProbe.grpc | object | `{}` | gRPC probe. |
-| deployment.livenessProbe | object | See below | Liveness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.livenessProbe | object, null | See below | Liveness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.livenessProbe.enabled | bool | `false` | Enable Liveness probe. |
 | deployment.livenessProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.livenessProbe.periodSeconds | int | `10` | Time between retries. |
@@ -142,13 +142,13 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.livenessProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.livenessProbe.grpc | object | `{}` | gRPC probe. |
 | deployment.resources | object | `{}` | Resource limits and requests for the pod. |
-| deployment.containerSecurityContext | object | `{"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
+| deployment.containerSecurityContext | object, null | `{"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
 | deployment.openshiftOAuthProxy.enabled | bool | `false` | Enable [OpenShift OAuth Proxy](https://github.com/openshift/oauth-proxy). |
 | deployment.openshiftOAuthProxy.port | int | `8080` | Port on which application is running inside container. |
 | deployment.openshiftOAuthProxy.secretName | string | `"openshift-oauth-proxy-tls"` | Secret name for the OAuth Proxy TLS certificate. |
 | deployment.openshiftOAuthProxy.image | string | `"openshift/oauth-proxy:latest"` | Image for the OAuth Proxy. |
 | deployment.openshiftOAuthProxy.disableTLSArg | bool | `false` | If disabled `--http-address=:8081` will be used instead of `--https-address=:8443`. It can be useful when an ingress is enabled for the application. |
-| deployment.securityContext | object | `nil` | Security Context for the pod. |
+| deployment.securityContext | object, null | `nil` | Security Context for the pod. |
 | deployment.command | list | `[]` | Command for the app container. |
 | deployment.args | list | `[]` | Args for the app container. |
 | deployment.automountServiceAccountToken | bool | `false` | Mount Service Account token. |
@@ -161,40 +161,41 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | persistence.enabled | bool | `false` | Enable persistence. |
 | persistence.mountPVC | bool | `false` | Whether to mount the created PVC to the deployment. |
 | persistence.mountPath | string | `"/"` | If `persistence.mountPVC` is enabled, where to mount the volume in the containers. |
-| persistence.name | string | `{{ include "application.name" $ }}-data` | Name of the PVC. |
+| persistence.name | string, null | `{{ include "application.name" $ }}-data` | Name of the PVC. |
 | persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for volume. |
 | persistence.storageClass | string | `nil` | Storage class for volume. If defined, use that value If set to "-" or "", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner. |
-| persistence.additionalLabels | object | `nil` | Additional labels for persistent volume. |
-| persistence.annotations | object | `nil` | Annotations for persistent volume. |
+| persistence.additionalLabels | object, null | `nil` | Additional labels for persistent volume. |
+| persistence.annotations | object, null | `nil` | Annotations for persistent volume. |
 | persistence.storageSize | string | `"8Gi"` | Size of the persistent volume. |
-| persistence.volumeMode | string | `""` | PVC Volume Mode. |
-| persistence.volumeName | string | `""` | Name of the volume. |
+| persistence.volumeMode | string, null | `""` | PVC Volume Mode. |
+| persistence.volumeName | string, null | `""` | Name of the volume. |
 
 ### Service Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | service.enabled | bool | `true` | Enable Service. |
-| service.additionalLabels | object | `nil` | Additional labels for service. |
-| service.annotations | object | `nil` | Annotations for service. |
+| service.additionalLabels | object, null | `nil` | Additional labels for service. |
+| service.annotations | object, null | `nil` | Annotations for service. |
 | service.ports | list | `[{"name":"http","port":8080,"protocol":"TCP","targetPort":8080}]` | Ports for applications service. |
+| service.ports[0].targetPort | int, string, null | `8080` | Target port on pods. Accepts port number or port name (IANA_SVC_NAME). |
 | service.type | string | `"ClusterIP"` | Type of service. |
-| service.clusterIP | string | `nil` | Fixed IP for a ClusterIP service. Set to `None` for an headless service |
-| service.loadBalancerClass | string | `nil` | LoadBalancer class name for LoadBalancer type services. |
+| service.clusterIP | string, null | `nil` | Fixed IP for a ClusterIP service. Set to `None` for an headless service |
+| service.loadBalancerClass | string, null | `nil` | LoadBalancer class name for LoadBalancer type services. |
 
 ### Ingress Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | ingress.enabled | bool | `false` | Enable Ingress. |
-| ingress.ingressClassName | string | `""` | Name of the ingress class. |
+| ingress.ingressClassName | string, null | `""` | Name of the ingress class. |
 | ingress.hosts[0].host | tpl | `"chart-example.local"` | Hostname. |
 | ingress.hosts[0].paths[0].path | string | `"/"` | Path. |
-| ingress.hosts[0].paths[0].pathType | string | `ImplementationSpecific` | Path type. |
-| ingress.hosts[0].paths[0].serviceName | string | `{{ include "application.name" $ }}` | Service name. |
-| ingress.hosts[0].paths[0].servicePort | string | `http` | Service port. |
-| ingress.additionalLabels | object | `nil` | Additional labels for ingress. |
-| ingress.annotations | object | `nil` | Annotations for ingress. |
+| ingress.hosts[0].paths[0].pathType | string, null | `ImplementationSpecific` | Path type. |
+| ingress.hosts[0].paths[0].serviceName | string, null | `{{ include "application.name" $ }}` | Service name. |
+| ingress.hosts[0].paths[0].servicePort | string, null | `http` | Service port. |
+| ingress.additionalLabels | object, null | `nil` | Additional labels for ingress. |
+| ingress.annotations | object, null | `nil` | Annotations for ingress. |
 | ingress.tls | list | `nil` | TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret. |
 
 ### HTTPRoute Parameters
@@ -203,39 +204,40 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 |-----|------|---------|-------------|
 | httpRoute.enabled | bool | `false` | Enable HTTPRoute (Gateway API). |
 | httpRoute.parentRefs | list | `nil` | Parent references for the HTTPRoute. Keys and values are evaluated as templates. |
-| httpRoute.useDefaultGateways | string | `nil` | The default Gateway scope to use for this Route. If unset (the default) or set to None, the Route will not be attached to any default Gateway; if set, it will be attached to any default Gateway supporting the named scope, subject to the usual rules about which Routes a Gateway is allowed to claim. |
-| httpRoute.gatewayNamespace | string | `""` | Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute. |
+| httpRoute.useDefaultGateways | string, null | `nil` | The default Gateway scope to use for this Route. If unset (the default) or set to None, the Route will not be attached to any default Gateway; if set, it will be attached to any default Gateway supporting the named scope, subject to the usual rules about which Routes a Gateway is allowed to claim. |
+| httpRoute.gatewayNamespace | string, null | `""` | Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute. |
 | httpRoute.hostnames | list | `nil` | Hostnames for the HTTPRoute. Values are evaluated as templates. |
 | httpRoute.additionalLabels | object | `{}` | Additional labels for HTTPRoute. |
 | httpRoute.annotations | object | `{}` | Annotations for HTTPRoute. |
 | httpRoute.rules | list | `[{"backendRefs":[{"name":"{{ include \"application.name\" $ }}","port":"{{ (first $.Values.service.ports).port }}"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. Keys and values are evaluated as templates. |
+| httpRoute.rules[0].backendRefs[0].port | int, tpl, null | `"{{ (first $.Values.service.ports).port }}"` | Port number or template expression for the backend service. |
 
 ### Route Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | route.enabled | bool | `false` | Deploy a Route (OpenShift) resource. |
-| route.additionalLabels | object | `nil` | Additional labels for Route. |
-| route.annotations | object | `nil` | Annotations for Route. |
-| route.host | string | `nil` | Explicit host. If no host is added then openshift inserts the default hostname. |
-| route.path | string | `nil` | Path. |
-| route.port | object | `{"targetPort":"http"}` | Service port. |
+| route.additionalLabels | object, null | `nil` | Additional labels for Route. |
+| route.annotations | object, null | `nil` | Annotations for Route. |
+| route.host | string, null | `nil` | Explicit host. If no host is added then openshift inserts the default hostname. |
+| route.path | string, null | `nil` | Path. |
+| route.port | object, null | `{"targetPort":"http"}` | Service port. |
 | route.to.weight | int | `100` | Service weight. |
 | route.wildcardPolicy | string | `"None"` | Wildcard policy. |
 | route.tls.termination | string | `"edge"` | TLS termination strategy. |
 | route.tls.insecureEdgeTerminationPolicy | string | `"Redirect"` | TLS insecure termination policy. |
-| route.alternateBackends | object | `nil` | Alternate backend with it's weight. |
+| route.alternateBackends | object, null | `nil` | Alternate backend with it's weight. |
 
 ### SecretProviderClass Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | secretProviderClass.enabled | bool | `false` | Deploy a [Secrets Store CSI Driver SecretProviderClass](https://secrets-store-csi-driver.sigs.k8s.io/) resource. |
-| secretProviderClass.name | string | `""` | Name of the SecretProviderClass. Required if `secretProviderClass.enabled` is set to `true`. |
-| secretProviderClass.provider | string | `""` | Name of the provider. Required if `secretProviderClass.enabled` is set to `true`. |
-| secretProviderClass.vaultAddress | string | `""` | Vault Address. Required if `secretProviderClass.provider` is set to `vault`. |
+| secretProviderClass.name | string, null | `""` | Name of the SecretProviderClass. Required if `secretProviderClass.enabled` is set to `true`. |
+| secretProviderClass.provider | string, null | `""` | Name of the provider. Required if `secretProviderClass.enabled` is set to `true`. |
+| secretProviderClass.vaultAddress | string, null | `""` | Vault Address. Required if `secretProviderClass.provider` is set to `vault`. |
 | secretProviderClass.roleName | tpl | `""` | Vault Role Name. Required if `secretProviderClass.provider` is set to `vault`. |
-| secretProviderClass.objects | string | `nil` | Objects definitions. |
+| secretProviderClass.objects | string, null | `nil` | Objects definitions. |
 | secretProviderClass.secretObjects | list | `nil` | Objects mapping. |
 
 ### ForecastleApp Parameters
@@ -243,11 +245,11 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | forecastle.enabled | bool | `false` | Deploy a [ForecastleApp](https://github.com/stakater/Forecastle) resource. |
-| forecastle.additionalLabels | object | `nil` | Additional labels for ForecastleApp. |
+| forecastle.additionalLabels | object, null | `nil` | Additional labels for ForecastleApp. |
 | forecastle.icon | string | `"https://raw.githubusercontent.com/stakater/ForecastleIcons/master/stakater-big.png"` | Icon URL. |
-| forecastle.displayName | string | `""` | Application Name. Required if `forecastle.enabled` is set to `true`. |
-| forecastle.group | string | `{{ .Release.Namespace }}` | Application Group. |
-| forecastle.properties | object | `nil` | Custom properties. |
+| forecastle.displayName | string, null | `""` | Application Name. Required if `forecastle.enabled` is set to `true`. |
+| forecastle.group | string, null | `{{ .Release.Namespace }}` | Application Group. |
+| forecastle.properties | object, null | `nil` | Custom properties. |
 | forecastle.networkRestricted | bool | `false` | Is application network restricted?. |
 
 ### RBAC Parameters
@@ -256,48 +258,48 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 |-----|------|---------|-------------|
 | rbac.enabled | bool | `true` | Enable RBAC. |
 | rbac.serviceAccount.create | bool | `false` | Specifies whether to create a dedicated service account. If set to `true`, a new service account will be created. |
-| rbac.serviceAccount.name | string | `""` | The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`: If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account ("default") is used. If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used. If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template. If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation. |
-| rbac.serviceAccount.additionalLabels | object | `nil` | Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account. |
-| rbac.serviceAccount.annotations | object | `nil` | Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account. |
+| rbac.serviceAccount.name | string, null | `""` | The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`: If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account ("default") is used. If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used. If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template. If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation. |
+| rbac.serviceAccount.additionalLabels | object, null | `nil` | Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account. |
+| rbac.serviceAccount.annotations | object, null | `nil` | Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account. |
 | rbac.roles | list | `nil` | Role definitions scoped to a single namespace. |
 | rbac.clusterRoles | list | `nil` | ClusterRole definitions with cluster-wide permissions. |
-| rbac.additionalLabels | object | `nil` | Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
-| rbac.annotations | object | `nil` | Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
+| rbac.additionalLabels | object, null | `nil` | Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
+| rbac.annotations | object, null | `nil` | Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
 
 ### ConfigMap Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | configMap.enabled | bool | `false` | Deploy additional ConfigMaps. |
-| configMap.additionalLabels | object | `nil` | Additional labels for ConfigMaps. |
-| configMap.annotations | object | `nil` | Annotations for ConfigMaps. |
-| configMap.files | object | `nil` | List of ConfigMap entries. Key will be used as a name suffix for the ConfigMap. Value is the ConfigMap content. |
+| configMap.additionalLabels | object, null | `nil` | Additional labels for ConfigMaps. |
+| configMap.annotations | object, null | `nil` | Annotations for ConfigMaps. |
+| configMap.files | object, null | `nil` | List of ConfigMap entries. Key will be used as a name suffix for the ConfigMap. Value is the ConfigMap content. |
 
 ### SealedSecret Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | sealedSecret.enabled | bool | `false` | Deploy [SealedSecret](https://github.com/bitnami-labs/sealed-secrets) resources. |
-| sealedSecret.additionalLabels | object | `nil` | Additional labels for SealedSecret. |
-| sealedSecret.annotations | object | `nil` | Annotations for SealedSecret. |
-| sealedSecret.files | object | `nil` | List of SealedSecret entries. Key will be used as a name suffix for the SealedSecret. Value is the SealedSecret content. |
+| sealedSecret.additionalLabels | object, null | `nil` | Additional labels for SealedSecret. |
+| sealedSecret.annotations | object, null | `nil` | Annotations for SealedSecret. |
+| sealedSecret.files | object, null | `nil` | List of SealedSecret entries. Key will be used as a name suffix for the SealedSecret. Value is the SealedSecret content. |
 
 ### Secret Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | secret.enabled | bool | `false` | Deploy additional Secret resources. |
-| secret.additionalLabels | object | `nil` | Additional labels for Secret. |
-| secret.annotations | object | `nil` | Annotations for Secret. |
-| secret.files | object | `nil` | List of Secrets entries. Key will be used as a name suffix for the Secret. There a three allowed modes: - `data`: Data is base64 encoded by the chart - `encodedData`: Use raw values (already base64ed) inside the data map - `stringData`: Use raw values inside the stringData map |
+| secret.additionalLabels | object, null | `nil` | Additional labels for Secret. |
+| secret.annotations | object, null | `nil` | Annotations for Secret. |
+| secret.files | object, null | `nil` | List of Secrets entries. Key will be used as a name suffix for the Secret. There a three allowed modes: - `data`: Data is base64 encoded by the chart - `encodedData`: Use raw values (already base64ed) inside the data map - `stringData`: Use raw values inside the stringData map |
 
 ### ServiceMonitor Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | serviceMonitor.enabled | bool | `false` | Deploy a ServiceMonitor (Prometheus Operator) resource. |
-| serviceMonitor.additionalLabels | object | `nil` | Additional labels for ServiceMonitor. |
-| serviceMonitor.annotations | object | `nil` | Annotations for ServiceMonitor. |
+| serviceMonitor.additionalLabels | object, null | `nil` | Additional labels for ServiceMonitor. |
+| serviceMonitor.annotations | object, null | `nil` | Annotations for ServiceMonitor. |
 | serviceMonitor.endpoints | list | `[{"interval":"5s","path":"/actuator/prometheus","port":"http"}]` | Service endpoints from which prometheus will scrape data. |
 
 ### Autoscaling - Horizontal Pod Autoscaling Parameters
@@ -305,8 +307,8 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaling. |
-| autoscaling.additionalLabels | object | `nil` | Additional labels for HPA. |
-| autoscaling.annotations | object | `nil` | Annotations for HPA. |
+| autoscaling.additionalLabels | object, null | `nil` | Additional labels for HPA. |
+| autoscaling.annotations | object, null | `nil` | Annotations for HPA. |
 | autoscaling.minReplicas | int | `1` | Minimum number of replicas. |
 | autoscaling.maxReplicas | int | `10` | Maximum number of replicas. |
 | autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":60,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":60,"type":"Utilization"}},"type":"Resource"}]` | Metrics used for autoscaling. |
@@ -316,30 +318,30 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaling. |
-| vpa.additionalLabels | object | `nil` | Additional labels for VPA. |
-| vpa.annotations | object | `nil` | Annotations for VPA. |
+| vpa.additionalLabels | object, null | `nil` | Additional labels for VPA. |
+| vpa.annotations | object, null | `nil` | Annotations for VPA. |
 | vpa.containerPolicies | list | `[]` | Container policies for individual containers. |
-| vpa.updatePolicy | object | `{"updateMode":"Auto"}` | Update policy. |
+| vpa.updatePolicy | object, null | `{"updateMode":"Auto"}` | Update policy. |
 
 ### EndpointMonitor Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | endpointMonitor.enabled | bool | `false` | Deploy an [IMC EndpointMonitor](https://github.com/stakater/IngressMonitorController) resource. |
-| endpointMonitor.additionalLabels | object | `nil` | Additional labels for EndpointMonitor. |
-| endpointMonitor.annotations | object | `nil` | Annotations for EndpointMonitor. |
+| endpointMonitor.additionalLabels | object, null | `nil` | Additional labels for EndpointMonitor. |
+| endpointMonitor.annotations | object, null | `nil` | Annotations for EndpointMonitor. |
 
 ### cert-manager Certificate Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | certificate.enabled | bool | `false` | Deploy a [cert-manager Certificate](https://cert-manager.io) resource. |
-| certificate.additionalLabels | object | `nil` | Additional labels for Certificate. |
-| certificate.annotations | object | `nil` | Annotations for Certificate. |
+| certificate.additionalLabels | object, null | `nil` | Additional labels for Certificate. |
+| certificate.annotations | object, null | `nil` | Annotations for Certificate. |
 | certificate.secretName | tpl | `"tls-cert"` | Name of the secret resource that will be automatically created and managed by this Certificate resource. |
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
-| certificate.subject | object | `nil` | Full X509 name specification for certificate. Keys and values are evaluated as templates. |
+| certificate.subject | object, null | `nil` | Full X509 name specification for certificate. Keys and values are evaluated as templates. |
 | certificate.commonName | tpl | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
 | certificate.keyAlgorithm | string | `"RSA"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"PKCS1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
@@ -368,9 +370,9 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | alertmanagerConfig.enabled | bool | `false` | Deploy an AlertmanagerConfig (Prometheus Operator) resource. |
-| alertmanagerConfig.selectionLabels | object | `{"alertmanagerConfig":"workload"}` | Labels to be picked up by Alertmanager to add it to base config. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html](OpenShift's AlermanagerConfig documentation) under .spec.alertmanagerConfigSelector. |
-| alertmanagerConfig.spec | object | `{"inhibitRules":[],"receivers":[],"route":null}` | AlertmanagerConfig spec. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html](OpenShift's AlermanagerConfig documentation). |
-| alertmanagerConfig.spec.route | object | `nil` | Route definition for alerts matching the resource’s namespace. It will be added to the generated Alertmanager configuration as a first-level route. |
+| alertmanagerConfig.selectionLabels | object, null | `{"alertmanagerConfig":"workload"}` | Labels to be picked up by Alertmanager to add it to base config. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html](OpenShift's AlermanagerConfig documentation) under .spec.alertmanagerConfigSelector. |
+| alertmanagerConfig.spec | object, null | `{"inhibitRules":[],"receivers":[],"route":null}` | AlertmanagerConfig spec. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html](OpenShift's AlermanagerConfig documentation). |
+| alertmanagerConfig.spec.route | object, null | `nil` | Route definition for alerts matching the resource’s namespace. It will be added to the generated Alertmanager configuration as a first-level route. |
 | alertmanagerConfig.spec.receivers | list | `[]` | List of receivers. |
 | alertmanagerConfig.spec.inhibitRules | list | `[]` | Inhibition rules that allows to mute alerts when other alerts are already firing. |
 
@@ -379,7 +381,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prometheusRule.enabled | bool | `false` | Deploy a PrometheusRule (Prometheus Operator) resource. |
-| prometheusRule.additionalLabels | object | `nil` | Additional labels for PrometheusRule. |
+| prometheusRule.additionalLabels | object, null | `nil` | Additional labels for PrometheusRule. |
 | prometheusRule.groups | list | `[]` | Groups with alerting rules. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/prometheusrule-monitoring-coreos-com-v1.html](OpenShift's PrometheusRule documentation). |
 
 ### ExternalSecret Parameters
@@ -387,21 +389,21 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | externalSecret.enabled | bool | `false` | Deploy [ExternalSecret](https://external-secrets.io/latest/) resources. |
-| externalSecret.additionalLabels | object | `nil` | Additional labels for ExternalSecret. |
-| externalSecret.annotations | object | `nil` | Annotations for ExternalSecret. |
-| externalSecret.secretStore | object | `{"kind":"SecretStore","name":"tenant-vault-secret-store"}` | Default values for the SecretStore. Can be overriden per ExternalSecret in the `externalSecret.files` object. |
+| externalSecret.additionalLabels | object, null | `nil` | Additional labels for ExternalSecret. |
+| externalSecret.annotations | object, null | `nil` | Annotations for ExternalSecret. |
+| externalSecret.secretStore | object, null | `{"kind":"SecretStore","name":"tenant-vault-secret-store"}` | Default values for the SecretStore. Can be overriden per ExternalSecret in the `externalSecret.files` object. |
 | externalSecret.secretStore.name | string | `"tenant-vault-secret-store"` | Name of the SecretStore to use. |
 | externalSecret.secretStore.kind | string | `"SecretStore"` | Kind of the SecretStore being refered to. |
 | externalSecret.refreshInterval | string | `"1m"` | RefreshInterval is the amount of time before the values are read again from the SecretStore provider. |
-| externalSecret.files | object | `nil` | List of ExternalSecret entries. Key will be used as a name suffix for the ExternalSecret. There a two allowed modes: - `data`: Data defines the connection between the Kubernetes Secret keys and the Provider data - `dataFrom`: Used to fetch all properties from the Provider key |
+| externalSecret.files | object, null | `nil` | List of ExternalSecret entries. Key will be used as a name suffix for the ExternalSecret. There a two allowed modes: - `data`: Data defines the connection between the Kubernetes Secret keys and the Provider data - `dataFrom`: Used to fetch all properties from the Provider key |
 
 ### NetworkPolicy Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | networkPolicy.enabled | bool | `false` | Enable Network Policy. |
-| networkPolicy.additionalLabels | object | `nil` | Additional labels for Network Policy. |
-| networkPolicy.annotations | object | `nil` | Annotations for Network Policy. |
+| networkPolicy.additionalLabels | object, null | `nil` | Additional labels for Network Policy. |
+| networkPolicy.annotations | object, null | `nil` | Annotations for Network Policy. |
 | networkPolicy.ingress | list | `nil` | Ingress rules for Network Policy. |
 | networkPolicy.egress | list | `nil` | Egress rules for Network Policy. |
 
@@ -410,29 +412,29 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | pdb.enabled | bool | `false` | Enable Pod Disruption Budget. |
-| pdb.minAvailable | int | `1` | Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. "25%"). |
-| pdb.maxUnavailable | int | `nil` | Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. "25%"). |
+| pdb.minAvailable | int, string, null | `1` | Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. "25%"). |
+| pdb.maxUnavailable | int, string, null | `nil` | Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. "25%"). |
 
 ### GrafanaDashboard Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | grafanaDashboard.enabled | bool | `false` | Deploy [GrafanaDashboard](https://github.com/grafana/grafana-operator) resources. |
-| grafanaDashboard.additionalLabels | object | `nil` | Additional labels for GrafanaDashboard. |
-| grafanaDashboard.annotations | object | `nil` | Annotations for GrafanaDashboard. |
-| grafanaDashboard.contents | object | `nil` | List of GrafanaDashboard entries. Key will be used as a name suffix for the GrafanaDashboard. Value is the GrafanaDashboard content. According to GrafanaDashboard behavior, `url` field takes precedence on the `json` field. |
+| grafanaDashboard.additionalLabels | object, null | `nil` | Additional labels for GrafanaDashboard. |
+| grafanaDashboard.annotations | object, null | `nil` | Annotations for GrafanaDashboard. |
+| grafanaDashboard.contents | object, null | `nil` | List of GrafanaDashboard entries. Key will be used as a name suffix for the GrafanaDashboard. Value is the GrafanaDashboard content. According to GrafanaDashboard behavior, `url` field takes precedence on the `json` field. |
 
 ### Backup Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backup.enabled | bool | `false` | Deploy a [Velero/OADP Backup](https://velero.io/docs/main/api-types/backup/) resource. |
-| backup.namespace | string | `{{ .Release.Namespace }}` | Namespace for Backup. |
-| backup.additionalLabels | object | `nil` | Additional labels for Backup. |
-| backup.annotations | object | `nil` | Annotations for Backup. |
+| backup.namespace | string, null | `{{ .Release.Namespace }}` | Namespace for Backup. |
+| backup.additionalLabels | object, null | `nil` | Additional labels for Backup. |
+| backup.annotations | object, null | `nil` | Annotations for Backup. |
 | backup.defaultVolumesToRestic | bool | `true` | Whether to use Restic to take snapshots of all pod volumes by default. |
 | backup.snapshotVolumes | bool | `true` | Whether to take snapshots of persistent volumes as part of the backup. |
-| backup.storageLocation | string | `nil` | Name of the backup storage location where the backup should be stored. |
+| backup.storageLocation | string, null | `nil` | Name of the backup storage location where the backup should be stored. |
 | backup.ttl | string | `"1h0m0s"` | How long the Backup should be retained for. |
 | backup.includedNamespaces | list | `[ {{ include "application.namespace" $ }} ]` | List of namespaces to include objects from. Keys and values are evaluated as templates. |
 | backup.includedResources | list | `nil` | List of resource types to include in the backup. |

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.strategy.type | string | `"RollingUpdate"` | Type of deployment strategy. |
 | deployment.reloadOnChange | bool | `true` | Reload deployment if attached Secret/ConfigMap changes. |
 | deployment.nodeSelector | object, null | `nil` | Select the node where the pods should be scheduled. |
-| deployment.hostAliases | list | `nil` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files. |
+| deployment.hostAliases | list, null | `nil` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files. |
 | deployment.initContainers | object, null | `nil` | Add init containers to the pods. |
 | deployment.fluentdConfigAnnotations | object, null | `nil` | Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>. |
-| deployment.replicas | int | `nil` | Number of replicas. |
+| deployment.replicas | int, null | `nil` | Number of replicas. |
 | deployment.imagePullSecrets | list | `[]` | List of secrets to be used for pulling the images. |
 | deployment.envFrom | object, null | `nil` | Mount environment variables from ConfigMap or Secret to the pod. Use `nameSuffix` for resources managed by this chart (name will be prefixed with application name), or `name` to reference an existing external ConfigMap or Secret not managed by this chart. See the README "Consuming environment variable in application chart" section for more details. |
 | deployment.env | object, null | `nil` | Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details. |
@@ -100,9 +100,9 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.volumeMounts | object, null | `nil` | Mount path for Volumes. Key is the name of the volume. Value is the volume mount definition. |
 | deployment.priorityClassName | string, null | `""` | Define the priority class for the pod. |
 | deployment.runtimeClassName | string, null | `""` | Set the runtimeClassName for the deployment's pods. |
-| deployment.tolerations | list | `nil` | Taint tolerations for the pods. |
+| deployment.tolerations | list, null | `nil` | Taint tolerations for the pods. |
 | deployment.affinity | object, null | `nil` | Affinity for the pods. |
-| deployment.topologySpreadConstraints | list | `nil` | Topology spread constraints for the pods. |
+| deployment.topologySpreadConstraints | list, null | `nil` | Topology spread constraints for the pods. |
 | deployment.revisionHistoryLimit | int | `2` | Number of ReplicaSet revisions to retain. |
 | deployment.image.repository | tpl | `""` | Repository. |
 | deployment.image.tag | tpl | `""` | Tag. |
@@ -152,18 +152,18 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.command | list | `[]` | Command for the app container. |
 | deployment.args | list | `[]` | Args for the app container. |
 | deployment.automountServiceAccountToken | bool | `false` | Mount Service Account token. |
-| deployment.ports | list | `nil` | List of ports for the app container. |
-| deployment.hostNetwork | bool | `nil` | Host network connectivity. |
-| deployment.terminationGracePeriodSeconds | int | `nil` | Gracefull termination period. |
-| deployment.minReadySeconds | int | `nil` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing. |
+| deployment.ports | list, null | `nil` | List of ports for the app container. |
+| deployment.hostNetwork | bool, null | `nil` | Host network connectivity. |
+| deployment.terminationGracePeriodSeconds | int, null | `nil` | Gracefull termination period. |
+| deployment.minReadySeconds | int, null | `nil` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing. |
 | deployment.lifecycle | object | `{}` | Lifecycle configuration for the pod. |
-| deployment.additionalContainers | list | `nil` | Additional containers besides init and app containers (without templating). |
+| deployment.additionalContainers | list, null | `nil` | Additional containers besides init and app containers (without templating). |
 | persistence.enabled | bool | `false` | Enable persistence. |
 | persistence.mountPVC | bool | `false` | Whether to mount the created PVC to the deployment. |
 | persistence.mountPath | string | `"/"` | If `persistence.mountPVC` is enabled, where to mount the volume in the containers. |
 | persistence.name | string, null | `{{ include "application.name" $ }}-data` | Name of the PVC. |
 | persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for volume. |
-| persistence.storageClass | string | `nil` | Storage class for volume. If defined, use that value If set to "-" or "", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner. |
+| persistence.storageClass | string, null | `nil` | Storage class for volume. If defined, use that value If set to "-" or "", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner. |
 | persistence.additionalLabels | object, null | `nil` | Additional labels for persistent volume. |
 | persistence.annotations | object, null | `nil` | Annotations for persistent volume. |
 | persistence.storageSize | string | `"8Gi"` | Size of the persistent volume. |
@@ -196,17 +196,17 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | ingress.hosts[0].paths[0].servicePort | string, null | `http` | Service port. |
 | ingress.additionalLabels | object, null | `nil` | Additional labels for ingress. |
 | ingress.annotations | object, null | `nil` | Annotations for ingress. |
-| ingress.tls | list | `nil` | TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret. |
+| ingress.tls | list, null | `nil` | TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret. |
 
 ### HTTPRoute Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | httpRoute.enabled | bool | `false` | Enable HTTPRoute (Gateway API). |
-| httpRoute.parentRefs | list | `nil` | Parent references for the HTTPRoute. Keys and values are evaluated as templates. |
+| httpRoute.parentRefs | list, null | `nil` | Parent references for the HTTPRoute. Keys and values are evaluated as templates. |
 | httpRoute.useDefaultGateways | string, null | `nil` | The default Gateway scope to use for this Route. If unset (the default) or set to None, the Route will not be attached to any default Gateway; if set, it will be attached to any default Gateway supporting the named scope, subject to the usual rules about which Routes a Gateway is allowed to claim. |
 | httpRoute.gatewayNamespace | string, null | `""` | Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute. |
-| httpRoute.hostnames | list | `nil` | Hostnames for the HTTPRoute. Values are evaluated as templates. |
+| httpRoute.hostnames | list, null | `nil` | Hostnames for the HTTPRoute. Values are evaluated as templates. |
 | httpRoute.additionalLabels | object | `{}` | Additional labels for HTTPRoute. |
 | httpRoute.annotations | object | `{}` | Annotations for HTTPRoute. |
 | httpRoute.rules | list | `[{"backendRefs":[{"name":"{{ include \"application.name\" $ }}","port":"{{ (first $.Values.service.ports).port }}"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. Keys and values are evaluated as templates. |
@@ -238,7 +238,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | secretProviderClass.vaultAddress | string, null | `""` | Vault Address. Required if `secretProviderClass.provider` is set to `vault`. |
 | secretProviderClass.roleName | tpl | `""` | Vault Role Name. Required if `secretProviderClass.provider` is set to `vault`. |
 | secretProviderClass.objects | string, null | `nil` | Objects definitions. |
-| secretProviderClass.secretObjects | list | `nil` | Objects mapping. |
+| secretProviderClass.secretObjects | list, null | `nil` | Objects mapping. |
 
 ### ForecastleApp Parameters
 
@@ -261,8 +261,8 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | rbac.serviceAccount.name | string, null | `""` | The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`: If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account ("default") is used. If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used. If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template. If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation. |
 | rbac.serviceAccount.additionalLabels | object, null | `nil` | Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account. |
 | rbac.serviceAccount.annotations | object, null | `nil` | Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account. |
-| rbac.roles | list | `nil` | Role definitions scoped to a single namespace. |
-| rbac.clusterRoles | list | `nil` | ClusterRole definitions with cluster-wide permissions. |
+| rbac.roles | list, null | `nil` | Role definitions scoped to a single namespace. |
+| rbac.clusterRoles | list, null | `nil` | ClusterRole definitions with cluster-wide permissions. |
 | rbac.additionalLabels | object, null | `nil` | Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
 | rbac.annotations | object, null | `nil` | Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
 
@@ -342,16 +342,16 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
 | certificate.subject | object, null | `nil` | Full X509 name specification for certificate. Keys and values are evaluated as templates. |
-| certificate.commonName | tpl | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
+| certificate.commonName | tpl, null | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
 | certificate.keyAlgorithm | string | `"RSA"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"PKCS1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |
 | certificate.isCA | bool | `false` | Mark this Certificate as valid for certificate signing. |
-| certificate.usages | list | `nil` | Set of x509 usages that are requested for the certificate. |
-| certificate.dnsNames | list | `nil` | List of DNS subjectAltNames to be set on the certificate. Keys and values are evaluated as templates. |
-| certificate.ipAddresses | list | `nil` | List of IP address subjectAltNames to be set on the certificate. |
-| certificate.uriSANs | list | `nil` | List of URI subjectAltNames to be set on the certificate. |
-| certificate.emailSANs | list | `nil` | List of email subjectAltNames to be set on the Certificate. |
+| certificate.usages | list, null | `nil` | Set of x509 usages that are requested for the certificate. |
+| certificate.dnsNames | list, null | `nil` | List of DNS subjectAltNames to be set on the certificate. Keys and values are evaluated as templates. |
+| certificate.ipAddresses | list, null | `nil` | List of IP address subjectAltNames to be set on the certificate. |
+| certificate.uriSANs | list, null | `nil` | List of URI subjectAltNames to be set on the certificate. |
+| certificate.emailSANs | list, null | `nil` | List of email subjectAltNames to be set on the Certificate. |
 | certificate.privateKey.enabled | bool | `false` | Enable Private Key for the certificate. |
 | certificate.privateKey.rotationPolicy | string | `"Always"` | Denotes how private keys should be generated or sourced when a certificate is being issued. |
 | certificate.issuerRef.name | string | `"ca-issuer"` | Reference to the issuer for this certificate. |
@@ -404,8 +404,8 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | networkPolicy.enabled | bool | `false` | Enable Network Policy. |
 | networkPolicy.additionalLabels | object, null | `nil` | Additional labels for Network Policy. |
 | networkPolicy.annotations | object, null | `nil` | Annotations for Network Policy. |
-| networkPolicy.ingress | list | `nil` | Ingress rules for Network Policy. |
-| networkPolicy.egress | list | `nil` | Egress rules for Network Policy. |
+| networkPolicy.ingress | list, null | `nil` | Ingress rules for Network Policy. |
+| networkPolicy.egress | list, null | `nil` | Egress rules for Network Policy. |
 
 ### PodDisruptionBudget Parameters
 
@@ -437,8 +437,8 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | backup.storageLocation | string, null | `nil` | Name of the backup storage location where the backup should be stored. |
 | backup.ttl | string | `"1h0m0s"` | How long the Backup should be retained for. |
 | backup.includedNamespaces | list | `[ {{ include "application.namespace" $ }} ]` | List of namespaces to include objects from. Keys and values are evaluated as templates. |
-| backup.includedResources | list | `nil` | List of resource types to include in the backup. |
-| backup.excludedResources | list | `nil` | List of resource types to exclude from the backup. |
+| backup.includedResources | list, null | `nil` | List of resource types to include in the backup. |
+| backup.excludedResources | list, null | `nil` | List of resource types to exclude from the backup. |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -25,15 +25,15 @@
             "alertmanagerConfig": {
               "default": "workload",
               "title": "alertmanagerConfig",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
           "title": "selectionLabels",
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "spec": {
           "description": "AlertmanagerConfig spec. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html](OpenShift's AlermanagerConfig documentation).",
@@ -67,7 +67,10 @@
           },
           "required": [],
           "title": "spec",
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "required": [],
@@ -77,6 +80,7 @@
     "applicationName": {
       "default": "`{{ .Release.Name }}`",
       "description": "Application name. Used as a prefix for all resource names.",
+      "required": [],
       "title": "applicationName",
       "type": [
         "string",
@@ -128,10 +132,7 @@
                       "name": {
                         "default": "cpu",
                         "title": "name",
-                        "type": [
-                          "string",
-                          "null"
-                        ]
+                        "type": "string"
                       },
                       "target": {
                         "properties": {
@@ -143,10 +144,7 @@
                           "type": {
                             "default": "Utilization",
                             "title": "type",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
+                            "type": "string"
                           }
                         },
                         "required": [],
@@ -161,10 +159,7 @@
                   "type": {
                     "default": "Resource",
                     "title": "type",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": "string"
                   }
                 },
                 "required": [],
@@ -177,10 +172,7 @@
                       "name": {
                         "default": "memory",
                         "title": "name",
-                        "type": [
-                          "string",
-                          "null"
-                        ]
+                        "type": "string"
                       },
                       "target": {
                         "properties": {
@@ -192,10 +184,7 @@
                           "type": {
                             "default": "Utilization",
                             "title": "type",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
+                            "type": "string"
                           }
                         },
                         "required": [],
@@ -210,10 +199,7 @@
                   "type": {
                     "default": "Resource",
                     "title": "type",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": "string"
                   }
                 },
                 "required": [],
@@ -274,10 +260,7 @@
           "default": "",
           "description": "List of resource types to exclude from the backup.",
           "title": "excludedResources",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "includedNamespaces": {
           "default": "`[ {{ include \"application.namespace\" $ }} ]`",
@@ -291,23 +274,18 @@
             "required": []
           },
           "title": "includedNamespaces",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "includedResources": {
           "default": "",
           "description": "List of resource types to include in the backup.",
           "title": "includedResources",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "namespace": {
           "default": "`{{ .Release.Namespace }}`",
           "description": "Namespace for Backup.",
+          "required": [],
           "title": "namespace",
           "type": [
             "string",
@@ -323,6 +301,7 @@
         "storageLocation": {
           "default": "",
           "description": "Name of the backup storage location where the backup should be stored.",
+          "required": [],
           "title": "storageLocation",
           "type": [
             "string",
@@ -333,10 +312,7 @@
           "default": "1h0m0s",
           "description": "How long the Backup should be retained for.",
           "title": "ttl",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         }
       },
       "required": [],
@@ -369,37 +345,25 @@
           "default": "",
           "description": "Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com).",
           "title": "commonName",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "dnsNames": {
           "default": "",
           "description": "List of DNS subjectAltNames to be set on the certificate. Keys and values are evaluated as templates.",
           "title": "dnsNames",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "duration": {
           "default": "8760h0m0s",
           "description": "The requested \"duration\" (i.e. lifetime) of the Certificate.",
           "title": "duration",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "emailSANs": {
           "default": "",
           "description": "List of email subjectAltNames to be set on the Certificate.",
           "title": "emailSANs",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "enabled": {
           "default": false,
@@ -411,10 +375,7 @@
           "default": "",
           "description": "List of IP address subjectAltNames to be set on the certificate.",
           "title": "ipAddresses",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "isCA": {
           "default": false,
@@ -428,28 +389,19 @@
               "default": "cert-manager.io",
               "description": "Group of the issuer resource being refered to.",
               "title": "group",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
             "kind": {
               "default": "ClusterIssuer",
               "description": "Kind of the issuer being referred to.",
               "title": "kind",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
             "name": {
               "default": "ca-issuer",
               "description": "Reference to the issuer for this certificate.",
               "title": "name",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
@@ -460,19 +412,13 @@
           "default": "RSA",
           "description": "Private key algorithm of the corresponding private key for this certificate.",
           "title": "keyAlgorithm",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "keyEncoding": {
           "default": "PKCS1",
           "description": "Private key cryptography standards (PKCS) for this certificate's private key to be encoded in.",
           "title": "keyEncoding",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "keySize": {
           "default": 2048,
@@ -500,19 +446,13 @@
                   "default": "test_key",
                   "description": "Key of the entry in the Secret resource's data field to be used.",
                   "title": "key",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string"
                 },
                 "name": {
                   "default": "test-creds",
                   "description": "Name of the Secret resource being referred to.",
                   "title": "name",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string"
                 }
               },
               "required": [],
@@ -531,19 +471,13 @@
                   "default": "test_key",
                   "description": "Key of the entry in the Secret resource's data field to be used.",
                   "title": "key",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string"
                 },
                 "name": {
                   "default": "test-creds",
                   "description": "Name of the Secret resource being referred to.",
                   "title": "name",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string"
                 }
               },
               "required": [],
@@ -568,10 +502,7 @@
               "default": "Always",
               "description": "Denotes how private keys should be generated or sourced when a certificate is being issued.",
               "title": "rotationPolicy",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
@@ -582,19 +513,13 @@
           "default": "720h0m0s",
           "description": "The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate.",
           "title": "renewBefore",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "secretName": {
           "default": "tls-cert",
           "description": "Name of the secret resource that will be automatically created and managed by this Certificate resource.",
           "title": "secretName",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "subject": {
           "default": "",
@@ -610,19 +535,13 @@
           "default": "",
           "description": "List of URI subjectAltNames to be set on the certificate.",
           "title": "uriSANs",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "usages": {
           "default": "",
           "description": "Set of x509 usages that are requested for the certificate.",
           "title": "usages",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         }
       },
       "required": [],
@@ -632,6 +551,7 @@
     "chartVersionOverride": {
       "default": "`{{ .Chart.Version }}`",
       "description": "Override chart version used in helm.sh/chart label. Useful for stable snapshot testing. @ignore",
+      "required": [],
       "title": "chartVersionOverride",
       "type": [
         "string",
@@ -641,6 +561,7 @@
     "componentOverride": {
       "default": "",
       "description": "Override the component label for all resources.",
+      "required": [],
       "title": "componentOverride",
       "type": [
         "string",
@@ -719,10 +640,7 @@
           "default": "",
           "description": "Additional containers besides init and app containers (without templating).",
           "title": "additionalContainers",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "additionalLabels": {
           "default": "",
@@ -802,7 +720,10 @@
           },
           "required": [],
           "title": "containerSecurityContext",
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "dnsConfig": {
           "default": "",
@@ -817,6 +738,7 @@
         "dnsPolicy": {
           "default": "",
           "description": "DNS Policy.",
+          "required": [],
           "title": "dnsPolicy",
           "type": [
             "string",
@@ -857,7 +779,7 @@
         },
         "fluentdConfigAnnotations": {
           "default": "",
-          "description": "Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>.",
+          "description": "Configuration details for fluentdConfigurations. Only works for specific setup, see \u003chttps://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb\u003e.",
           "required": [],
           "title": "fluentdConfigAnnotations",
           "type": [
@@ -869,19 +791,13 @@
           "default": "",
           "description": "Mapping between IP and hostnames that will be injected as entries in the pod's hosts files.",
           "title": "hostAliases",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "hostNetwork": {
           "default": "",
           "description": "Host network connectivity.",
           "title": "hostNetwork",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": "boolean"
         },
         "image": {
           "properties": {
@@ -889,37 +805,25 @@
               "default": "",
               "description": "Image digest. If resolved to a non-empty value, digest takes precedence on the tag.",
               "title": "digest",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
             "pullPolicy": {
               "default": "IfNotPresent",
               "description": "Image pull policy.",
               "title": "pullPolicy",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
             "repository": {
               "default": "",
               "description": "Repository.",
               "title": "repository",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
             "tag": {
               "default": "",
               "description": "Tag.",
               "title": "tag",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
@@ -1020,10 +924,7 @@
           "default": "",
           "description": "Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing.",
           "title": "minReadySeconds",
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": "integer"
         },
         "nodeSelector": {
           "default": "",
@@ -1053,10 +954,7 @@
               "default": "openshift/oauth-proxy:latest",
               "description": "Image for the OAuth Proxy.",
               "title": "image",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
             "port": {
               "default": 8080,
@@ -1068,10 +966,7 @@
               "default": "openshift-oauth-proxy-tls",
               "description": "Secret name for the OAuth Proxy TLS certificate.",
               "title": "secretName",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
@@ -1092,14 +987,12 @@
           "default": "",
           "description": "List of ports for the app container.",
           "title": "ports",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "priorityClassName": {
           "default": "",
           "description": "Define the priority class for the pod.",
+          "required": [],
           "title": "priorityClassName",
           "type": [
             "string",
@@ -1182,10 +1075,7 @@
           "default": "",
           "description": "Number of replicas.",
           "title": "replicas",
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": "integer"
         },
         "resources": {
           "description": "Resource limits and requests for the pod.",
@@ -1202,6 +1092,7 @@
         "runtimeClassName": {
           "default": "",
           "description": "Set the runtimeClassName for the deployment's pods.",
+          "required": [],
           "title": "runtimeClassName",
           "type": [
             "string",
@@ -1290,10 +1181,7 @@
               "default": "RollingUpdate",
               "description": "Type of deployment strategy.",
               "title": "type",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
@@ -1304,28 +1192,19 @@
           "default": "",
           "description": "Gracefull termination period.",
           "title": "terminationGracePeriodSeconds",
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": "integer"
         },
         "tolerations": {
           "default": "",
           "description": "Taint tolerations for the pods.",
           "title": "tolerations",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "topologySpreadConstraints": {
           "default": "",
           "description": "Topology spread constraints for the pods.",
           "title": "topologySpreadConstraints",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "volumeMounts": {
           "default": "",
@@ -1427,10 +1306,7 @@
           "default": "1m",
           "description": "RefreshInterval is the amount of time before the values are read again from the SecretStore provider.",
           "title": "refreshInterval",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "secretStore": {
           "description": "Default values for the SecretStore. Can be overriden per ExternalSecret in the `externalSecret.files` object.",
@@ -1439,24 +1315,21 @@
               "default": "SecretStore",
               "description": "Kind of the SecretStore being refered to.",
               "title": "kind",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
             "name": {
               "default": "tenant-vault-secret-store",
               "description": "Name of the SecretStore to use.",
               "title": "name",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
           "title": "secretStore",
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "required": [],
@@ -1466,10 +1339,11 @@
     "extraObjects": {
       "default": "",
       "description": "Extra K8s manifests to deploy. Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are evaluated as templates.",
+      "required": [],
       "title": "extraObjects",
       "type": [
-        "object",
         "array",
+        "object",
         "null"
       ]
     },
@@ -1488,6 +1362,7 @@
         "displayName": {
           "default": "",
           "description": "Application Name. Required if `forecastle.enabled` is set to `true`.",
+          "required": [],
           "title": "displayName",
           "type": [
             "string",
@@ -1503,6 +1378,7 @@
         "group": {
           "default": "`{{ .Release.Namespace }}`",
           "description": "Application Group.",
+          "required": [],
           "title": "group",
           "type": [
             "string",
@@ -1513,10 +1389,7 @@
           "default": "https://raw.githubusercontent.com/stakater/ForecastleIcons/master/stakater-big.png",
           "description": "Icon URL.",
           "title": "icon",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "networkRestricted": {
           "default": false,
@@ -1611,6 +1484,7 @@
         "gatewayNamespace": {
           "default": "",
           "description": "Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute.",
+          "required": [],
           "title": "gatewayNamespace",
           "type": [
             "string",
@@ -1621,19 +1495,13 @@
           "default": "",
           "description": "Hostnames for the HTTPRoute. Values are evaluated as templates.",
           "title": "hostnames",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "parentRefs": {
           "default": "",
           "description": "Parent references for the HTTPRoute. Keys and values are evaluated as templates.",
           "title": "parentRefs",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "rules": {
           "description": "Rules for HTTPRoute. Keys and values are evaluated as templates.",
@@ -1649,13 +1517,12 @@
                             "name": {
                               "default": "{{ include \"application.name\" $ }}",
                               "title": "name",
-                              "type": [
-                                "string",
-                                "null"
-                              ]
+                              "type": "string"
                             },
                             "port": {
                               "default": "{{ (first $.Values.service.ports).port }}",
+                              "description": "Port number or template expression for the backend service.",
+                              "required": [],
                               "title": "port",
                               "type": [
                                 "integer",
@@ -1683,18 +1550,12 @@
                                 "type": {
                                   "default": "PathPrefix",
                                   "title": "type",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ]
+                                  "type": "string"
                                 },
                                 "value": {
                                   "default": "/",
                                   "title": "value",
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ]
+                                  "type": "string"
                                 }
                               },
                               "required": [],
@@ -1724,6 +1585,7 @@
         "useDefaultGateways": {
           "default": "",
           "description": "The default Gateway scope to use for this Route. If unset (the default) or set to None, the Route will not be attached to any default Gateway; if set, it will be attached to any default Gateway supporting the named scope, subject to the usual rules about which Routes a Gateway is allowed to claim.",
+          "required": [],
           "title": "useDefaultGateways",
           "type": [
             "string",
@@ -1772,10 +1634,7 @@
                     "default": "chart-example.local",
                     "description": "Hostname.",
                     "title": "host",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": "string"
                   },
                   "paths": {
                     "items": {
@@ -1786,14 +1645,12 @@
                               "default": "/",
                               "description": "Path.",
                               "title": "path",
-                              "type": [
-                                "string",
-                                "null"
-                              ]
+                              "type": "string"
                             },
                             "pathType": {
                               "default": "`ImplementationSpecific`",
                               "description": "Path type.",
+                              "required": [],
                               "title": "pathType",
                               "type": [
                                 "string",
@@ -1803,6 +1660,7 @@
                             "serviceName": {
                               "default": "`{{ include \"application.name\" $ }}`",
                               "description": "Service name.",
+                              "required": [],
                               "title": "serviceName",
                               "type": [
                                 "string",
@@ -1812,6 +1670,7 @@
                             "servicePort": {
                               "default": "`http`",
                               "description": "Service port.",
+                              "required": [],
                               "title": "servicePort",
                               "type": [
                                 "string",
@@ -1841,6 +1700,7 @@
         "ingressClassName": {
           "default": "",
           "description": "Name of the ingress class.",
+          "required": [],
           "title": "ingressClassName",
           "type": [
             "string",
@@ -1851,10 +1711,7 @@
           "default": "",
           "description": "TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret.",
           "title": "tls",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         }
       },
       "required": [],
@@ -1887,6 +1744,7 @@
     "namespaceOverride": {
       "default": "",
       "description": "Override the namespace for all resources.",
+      "required": [],
       "title": "namespaceOverride",
       "type": [
         "string",
@@ -1919,10 +1777,7 @@
           "default": "",
           "description": "Egress rules for Network Policy.",
           "title": "egress",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "enabled": {
           "default": false,
@@ -1934,10 +1789,7 @@
           "default": "",
           "description": "Ingress rules for Network Policy.",
           "title": "ingress",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         }
       },
       "required": [],
@@ -1947,6 +1799,7 @@
     "partOfOverride": {
       "default": "",
       "description": "Override the partOf label for all resources.",
+      "required": [],
       "title": "partOfOverride",
       "type": [
         "string",
@@ -1964,6 +1817,7 @@
         "maxUnavailable": {
           "default": "",
           "description": "Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. \"25%\").",
+          "required": [],
           "title": "maxUnavailable",
           "type": [
             "integer",
@@ -1974,6 +1828,7 @@
         "minAvailable": {
           "default": 1,
           "description": "Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. \"25%\").",
+          "required": [],
           "title": "minAvailable",
           "type": [
             "integer",
@@ -1992,10 +1847,7 @@
           "default": "ReadWriteOnce",
           "description": "Access mode for volume.",
           "title": "accessMode",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "additionalLabels": {
           "default": "",
@@ -2033,14 +1885,12 @@
           "default": "/",
           "description": "If `persistence.mountPVC` is enabled, where to mount the volume in the containers.",
           "title": "mountPath",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "name": {
           "default": "`{{ include \"application.name\" $ }}-data`",
           "description": "Name of the PVC.",
+          "required": [],
           "title": "name",
           "type": [
             "string",
@@ -2051,23 +1901,18 @@
           "default": "null",
           "description": "Storage class for volume. If defined, use that value If set to \"-\" or \"\", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner.",
           "title": "storageClass",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "storageSize": {
           "default": "8Gi",
           "description": "Size of the persistent volume.",
           "title": "storageSize",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "volumeMode": {
           "default": "",
           "description": "PVC Volume Mode.",
+          "required": [],
           "title": "volumeMode",
           "type": [
             "string",
@@ -2077,6 +1922,7 @@
         "volumeName": {
           "default": "",
           "description": "Name of the volume.",
+          "required": [],
           "title": "volumeName",
           "type": [
             "string",
@@ -2145,10 +1991,7 @@
           "default": "",
           "description": "ClusterRole definitions with cluster-wide permissions.",
           "title": "clusterRoles",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "enabled": {
           "default": true,
@@ -2160,10 +2003,7 @@
           "default": "",
           "description": "Role definitions scoped to a single namespace.",
           "title": "roles",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "serviceAccount": {
           "properties": {
@@ -2196,6 +2036,7 @@
             "name": {
               "default": "",
               "description": "The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`: If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account (\"default\") is used. If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used. If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template. If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation.",
+              "required": [],
               "title": "name",
               "type": [
                 "string",
@@ -2253,6 +2094,7 @@
         "host": {
           "default": "",
           "description": "Explicit host. If no host is added then openshift inserts the default hostname.",
+          "required": [],
           "title": "host",
           "type": [
             "string",
@@ -2262,6 +2104,7 @@
         "path": {
           "default": "",
           "description": "Path.",
+          "required": [],
           "title": "path",
           "type": [
             "string",
@@ -2274,15 +2117,15 @@
             "targetPort": {
               "default": "http",
               "title": "targetPort",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
           "title": "port",
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "tls": {
           "properties": {
@@ -2290,19 +2133,13 @@
               "default": "Redirect",
               "description": "TLS insecure termination policy.",
               "title": "insecureEdgeTerminationPolicy",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
             "termination": {
               "default": "edge",
               "description": "TLS termination strategy.",
               "title": "termination",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
@@ -2326,10 +2163,7 @@
           "default": "None",
           "description": "Wildcard policy.",
           "title": "wildcardPolicy",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         }
       },
       "required": [],
@@ -2433,6 +2267,7 @@
         "name": {
           "default": "",
           "description": "Name of the SecretProviderClass. Required if `secretProviderClass.enabled` is set to `true`.",
+          "required": [],
           "title": "name",
           "type": [
             "string",
@@ -2442,6 +2277,7 @@
         "objects": {
           "default": "",
           "description": "Objects definitions.",
+          "required": [],
           "title": "objects",
           "type": [
             "string",
@@ -2451,6 +2287,7 @@
         "provider": {
           "default": "",
           "description": "Name of the provider. Required if `secretProviderClass.enabled` is set to `true`.",
+          "required": [],
           "title": "provider",
           "type": [
             "string",
@@ -2461,23 +2298,18 @@
           "default": "",
           "description": "Vault Role Name. Required if `secretProviderClass.provider` is set to `vault`.",
           "title": "roleName",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "secretObjects": {
           "default": "",
           "description": "Objects mapping.",
           "title": "secretObjects",
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "vaultAddress": {
           "default": "",
           "description": "Vault Address. Required if `secretProviderClass.provider` is set to `vault`.",
+          "required": [],
           "title": "vaultAddress",
           "type": [
             "string",
@@ -2514,6 +2346,7 @@
         "clusterIP": {
           "default": "",
           "description": "Fixed IP for a ClusterIP service. Set to `None` for an headless service",
+          "required": [],
           "title": "clusterIP",
           "type": [
             "string",
@@ -2529,6 +2362,7 @@
         "loadBalancerClass": {
           "default": "",
           "description": "LoadBalancer class name for LoadBalancer type services.",
+          "required": [],
           "title": "loadBalancerClass",
           "type": [
             "string",
@@ -2544,10 +2378,7 @@
                   "name": {
                     "default": "http",
                     "title": "name",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": "string"
                   },
                   "port": {
                     "default": 8080,
@@ -2557,13 +2388,12 @@
                   "protocol": {
                     "default": "TCP",
                     "title": "protocol",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": "string"
                   },
                   "targetPort": {
                     "default": 8080,
+                    "description": "Target port on pods. Accepts port number or port name (IANA_SVC_NAME).",
+                    "required": [],
                     "title": "targetPort",
                     "type": [
                       "integer",
@@ -2585,10 +2415,7 @@
           "default": "ClusterIP",
           "description": "Type of service.",
           "title": "type",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         }
       },
       "required": [],
@@ -2632,26 +2459,17 @@
                   "interval": {
                     "default": "5s",
                     "title": "interval",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": "string"
                   },
                   "path": {
                     "default": "/actuator/prometheus",
                     "title": "path",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": "string"
                   },
                   "port": {
                     "default": "http",
                     "title": "port",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": "string"
                   }
                 },
                 "required": [],
@@ -2710,15 +2528,15 @@
             "updateMode": {
               "default": "Auto",
               "title": "updateMode",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           },
           "required": [],
           "title": "updatePolicy",
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "required": [],

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -259,8 +259,12 @@
         "excludedResources": {
           "default": "",
           "description": "List of resource types to exclude from the backup.",
+          "required": [],
           "title": "excludedResources",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "includedNamespaces": {
           "default": "`[ {{ include \"application.namespace\" $ }} ]`",
@@ -279,8 +283,12 @@
         "includedResources": {
           "default": "",
           "description": "List of resource types to include in the backup.",
+          "required": [],
           "title": "includedResources",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "namespace": {
           "default": "`{{ .Release.Namespace }}`",
@@ -344,14 +352,22 @@
         "commonName": {
           "default": "",
           "description": "Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com).",
+          "required": [],
           "title": "commonName",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "dnsNames": {
           "default": "",
           "description": "List of DNS subjectAltNames to be set on the certificate. Keys and values are evaluated as templates.",
+          "required": [],
           "title": "dnsNames",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "duration": {
           "default": "8760h0m0s",
@@ -362,8 +378,12 @@
         "emailSANs": {
           "default": "",
           "description": "List of email subjectAltNames to be set on the Certificate.",
+          "required": [],
           "title": "emailSANs",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "enabled": {
           "default": false,
@@ -374,8 +394,12 @@
         "ipAddresses": {
           "default": "",
           "description": "List of IP address subjectAltNames to be set on the certificate.",
+          "required": [],
           "title": "ipAddresses",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "isCA": {
           "default": false,
@@ -534,14 +558,22 @@
         "uriSANs": {
           "default": "",
           "description": "List of URI subjectAltNames to be set on the certificate.",
+          "required": [],
           "title": "uriSANs",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "usages": {
           "default": "",
           "description": "Set of x509 usages that are requested for the certificate.",
+          "required": [],
           "title": "usages",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
       "required": [],
@@ -639,8 +671,12 @@
         "additionalContainers": {
           "default": "",
           "description": "Additional containers besides init and app containers (without templating).",
+          "required": [],
           "title": "additionalContainers",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "additionalLabels": {
           "default": "",
@@ -790,14 +826,22 @@
         "hostAliases": {
           "default": "",
           "description": "Mapping between IP and hostnames that will be injected as entries in the pod's hosts files.",
+          "required": [],
           "title": "hostAliases",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "hostNetwork": {
           "default": "",
           "description": "Host network connectivity.",
+          "required": [],
           "title": "hostNetwork",
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "image": {
           "properties": {
@@ -923,8 +967,12 @@
         "minReadySeconds": {
           "default": "",
           "description": "Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing.",
+          "required": [],
           "title": "minReadySeconds",
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "nodeSelector": {
           "default": "",
@@ -986,8 +1034,12 @@
         "ports": {
           "default": "",
           "description": "List of ports for the app container.",
+          "required": [],
           "title": "ports",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "priorityClassName": {
           "default": "",
@@ -1074,8 +1126,12 @@
         "replicas": {
           "default": "",
           "description": "Number of replicas.",
+          "required": [],
           "title": "replicas",
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "resources": {
           "description": "Resource limits and requests for the pod.",
@@ -1191,20 +1247,32 @@
         "terminationGracePeriodSeconds": {
           "default": "",
           "description": "Gracefull termination period.",
+          "required": [],
           "title": "terminationGracePeriodSeconds",
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "tolerations": {
           "default": "",
           "description": "Taint tolerations for the pods.",
+          "required": [],
           "title": "tolerations",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "topologySpreadConstraints": {
           "default": "",
           "description": "Topology spread constraints for the pods.",
+          "required": [],
           "title": "topologySpreadConstraints",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "volumeMounts": {
           "default": "",
@@ -1494,14 +1562,22 @@
         "hostnames": {
           "default": "",
           "description": "Hostnames for the HTTPRoute. Values are evaluated as templates.",
+          "required": [],
           "title": "hostnames",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "parentRefs": {
           "default": "",
           "description": "Parent references for the HTTPRoute. Keys and values are evaluated as templates.",
+          "required": [],
           "title": "parentRefs",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "rules": {
           "description": "Rules for HTTPRoute. Keys and values are evaluated as templates.",
@@ -1710,8 +1786,12 @@
         "tls": {
           "default": "",
           "description": "TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret.",
+          "required": [],
           "title": "tls",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
       "required": [],
@@ -1776,8 +1856,12 @@
         "egress": {
           "default": "",
           "description": "Egress rules for Network Policy.",
+          "required": [],
           "title": "egress",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "enabled": {
           "default": false,
@@ -1788,8 +1872,12 @@
         "ingress": {
           "default": "",
           "description": "Ingress rules for Network Policy.",
+          "required": [],
           "title": "ingress",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
       "required": [],
@@ -1900,8 +1988,12 @@
         "storageClass": {
           "default": "null",
           "description": "Storage class for volume. If defined, use that value If set to \"-\" or \"\", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner.",
+          "required": [],
           "title": "storageClass",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "storageSize": {
           "default": "8Gi",
@@ -1990,8 +2082,12 @@
         "clusterRoles": {
           "default": "",
           "description": "ClusterRole definitions with cluster-wide permissions.",
+          "required": [],
           "title": "clusterRoles",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "enabled": {
           "default": true,
@@ -2002,8 +2098,12 @@
         "roles": {
           "default": "",
           "description": "Role definitions scoped to a single namespace.",
+          "required": [],
           "title": "roles",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "serviceAccount": {
           "properties": {
@@ -2303,8 +2403,12 @@
         "secretObjects": {
           "default": "",
           "description": "Objects mapping.",
+          "required": [],
           "title": "secretObjects",
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "vaultAddress": {
           "default": "",

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -185,7 +185,7 @@ deployment:
   # -- (object, null) Select the node where the pods should be scheduled.
   # @section -- Deployment Parameters
   nodeSelector:
-  # -- (list) Mapping between IP and hostnames that will be injected as entries in the pod's hosts files.
+  # -- (list, null) Mapping between IP and hostnames that will be injected as entries in the pod's hosts files.
   # @section -- Deployment Parameters
   hostAliases:
   # - ip: "127.0.0.1"
@@ -216,7 +216,7 @@ deployment:
     #   slack:
     #     webhookURL: https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX
     #     channelName: "#channel"
-  # -- (int) Number of replicas.
+  # -- (int, null) Number of replicas.
   # @section -- Deployment Parameters
   replicas:
   # -- (list) List of secrets to be used for pulling the images.
@@ -284,7 +284,7 @@ deployment:
   # -- (string, null) Set the runtimeClassName for the deployment's pods.
   # @section -- Deployment Parameters
   runtimeClassName: ""
-  # -- (list) Taint tolerations for the pods.
+  # -- (list, null) Taint tolerations for the pods.
   # @section -- Deployment Parameters
   tolerations:
     # - key: "dedicated"
@@ -302,7 +302,7 @@ deployment:
   #          operator: In
   #          values:
   #          - ssd
-  # -- (list) Topology spread constraints for the pods.
+  # -- (list, null) Topology spread constraints for the pods.
   # @section -- Deployment Parameters
   topologySpreadConstraints:
     # - maxSkew: 1
@@ -493,7 +493,7 @@ deployment:
   # -- (bool) Mount Service Account token.
   # @section -- Deployment Parameters
   automountServiceAccountToken: false
-  # -- (list) List of ports for the app container.
+  # -- (list, null) List of ports for the app container.
   # @section -- Deployment Parameters
   ports:
   # - containerPort: 8080
@@ -502,13 +502,13 @@ deployment:
   # - containerPort: 8443
   #   name: https
   #   protocol: TCP
-  # -- (bool) Host network connectivity.
+  # -- (bool, null) Host network connectivity.
   # @section -- Deployment Parameters
   hostNetwork:
-  # -- (int) Gracefull termination period.
+  # -- (int, null) Gracefull termination period.
   # @section -- Deployment Parameters
   terminationGracePeriodSeconds:
-  # -- (int) Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing.
+  # -- (int, null) Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing.
   # @section -- Deployment Parameters
   minReadySeconds:
   # -- (object) Lifecycle configuration for the pod.
@@ -517,7 +517,7 @@ deployment:
     # preStop:
     #   exec:
     #     command: ["/bin/bash", "-c", "sleep 20"]
-  # -- (list) Additional containers besides init and app containers (without templating).
+  # -- (list, null) Additional containers besides init and app containers (without templating).
   # @section -- Deployment Parameters
   additionalContainers:
   # - name: sidecar-container
@@ -542,7 +542,7 @@ persistence:
   # -- (string) Access mode for volume.
   # @section -- Deployment Parameters
   accessMode: ReadWriteOnce
-  # -- (string) Storage class for volume.
+  # -- (string, null) Storage class for volume.
   # If defined, use that value
   # If set to "-" or "", disable dynamic provisioning
   # If undefined or set to null (the default), no storageClass spec is
@@ -643,7 +643,7 @@ ingress:
     # kubernetes.io/ingress.class: external-ingress
     # ingress.kubernetes.io/rewrite-target: /
     # ingress.kubernetes.io/force-ssl-redirect: true
-  # -- (list) TLS configuration for ingress.
+  # -- (list, null) TLS configuration for ingress.
   # Secrets must exist in the namespace.
   # You may also configure Certificate resource to generate the secret.
   # @section -- Ingress Parameters
@@ -656,7 +656,7 @@ httpRoute:
   # -- (bool) Enable HTTPRoute (Gateway API).
   # @section -- HTTPRoute Parameters
   enabled: false
-  # -- (list) Parent references for the HTTPRoute. Keys and values are evaluated as templates.
+  # -- (list, null) Parent references for the HTTPRoute. Keys and values are evaluated as templates.
   # @section -- HTTPRoute Parameters
   parentRefs:
     # - name: my-gateway
@@ -672,7 +672,7 @@ httpRoute:
   # If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute.
   # @section -- HTTPRoute Parameters
   gatewayNamespace: ""
-  # -- (list) Hostnames for the HTTPRoute. Values are evaluated as templates.
+  # -- (list, null) Hostnames for the HTTPRoute. Values are evaluated as templates.
   # @section -- HTTPRoute Parameters
   hostnames:
   # -- (object) Additional labels for HTTPRoute.
@@ -769,7 +769,7 @@ secretProviderClass:
     # - objectName: MONGO_HOST
     #   secretPath: testing/data/mongoDb
     #   secretKey: MONGO_HOST
-  # -- (list) Objects mapping.
+  # -- (list, null) Objects mapping.
   # @section -- SecretProviderClass Parameters
   secretObjects:
     # - data:
@@ -827,7 +827,7 @@ rbac:
     # @section -- RBAC Parameters
     annotations:
       # key: value
-  # -- (list) Role definitions scoped to a single namespace.
+  # -- (list, null) Role definitions scoped to a single namespace.
   # @section -- RBAC Parameters
   roles:
   # - name: configmaps
@@ -846,7 +846,7 @@ rbac:
   #     - secrets
   #     verbs:
   #     - get
-  # -- (list) ClusterRole definitions with cluster-wide permissions.
+  # -- (list, null) ClusterRole definitions with cluster-wide permissions.
   # @section -- RBAC Parameters
   clusterRoles:
   # - name: configmaps
@@ -1084,7 +1084,7 @@ certificate:
   #    - Stockholm
   #  provinces:
   #    - Stockholm
-  # -- (tpl) Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com).
+  # -- (tpl, null) Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com).
   # @section -- cert-manager Certificate Parameters
   commonName:
   # commonName: admin-app
@@ -1100,24 +1100,24 @@ certificate:
   # -- (bool) Mark this Certificate as valid for certificate signing.
   # @section -- cert-manager Certificate Parameters
   isCA: false
-  # -- (list) Set of x509 usages that are requested for the certificate.
+  # -- (list, null) Set of x509 usages that are requested for the certificate.
   # @section -- cert-manager Certificate Parameters
   usages:
   #  - digital signature
   #  - client auth
-  # -- (list) List of DNS subjectAltNames to be set on the certificate. Keys and values are evaluated as templates.
+  # -- (list, null) List of DNS subjectAltNames to be set on the certificate. Keys and values are evaluated as templates.
   # @section -- cert-manager Certificate Parameters
   dnsNames:
   #  - admin-app
-  # -- (list) List of IP address subjectAltNames to be set on the certificate.
+  # -- (list, null) List of IP address subjectAltNames to be set on the certificate.
   # @section -- cert-manager Certificate Parameters
   ipAddresses:
   #  - 192.168.0.5
-  # -- (list) List of URI subjectAltNames to be set on the certificate.
+  # -- (list, null) List of URI subjectAltNames to be set on the certificate.
   # @section -- cert-manager Certificate Parameters
   uriSANs:
   #  - spiffe://cluster.local/ns/sandbox/sa/example
-  # -- (list) List of email subjectAltNames to be set on the Certificate.
+  # -- (list, null) List of email subjectAltNames to be set on the Certificate.
   # @section -- cert-manager Certificate Parameters
   emailSANs:
   #  - foo@bar.tld
@@ -1294,7 +1294,7 @@ networkPolicy:
   # @section -- NetworkPolicy Parameters
   annotations:
   #   key: value
-  # -- (list) Ingress rules for Network Policy.
+  # -- (list, null) Ingress rules for Network Policy.
   # @section -- NetworkPolicy Parameters
   ingress:
   # - from:
@@ -1311,7 +1311,7 @@ networkPolicy:
   #   ports:
   #   - protocol: TCP
   #     port: 6379
-  # -- (list) Egress rules for Network Policy.
+  # -- (list, null) Egress rules for Network Policy.
   # @section -- NetworkPolicy Parameters
   egress:
   #   - to:
@@ -1403,10 +1403,10 @@ backup:
   # @section -- Backup Parameters
   includedNamespaces:
   - '{{ include "application.namespace" $ }}'
-  # -- (list) List of resource types to include in the backup.
+  # -- (list, null) List of resource types to include in the backup.
   # @section -- Backup Parameters
   includedResources:
-  # -- (list) List of resource types to exclude from the backup.
+  # -- (list, null) List of resource types to exclude from the backup.
   # @section -- Backup Parameters
   excludedResources:
 

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -1,26 +1,26 @@
-# -- (string) Override the namespace for all resources.
+# -- (string, null) Override the namespace for all resources.
 # @section -- Parameters
 namespaceOverride: ""
 
-# -- (string) Override the component label for all resources.
+# -- (string, null) Override the component label for all resources.
 # @section -- Parameters
 componentOverride: ""
 
-# -- (string) Override the partOf label for all resources.
+# -- (string, null) Override the partOf label for all resources.
 # @section -- Parameters
 partOfOverride: ""
 
-# -- (string) Application name. Used as a prefix for all resource names.
+# -- (string, null) Application name. Used as a prefix for all resource names.
 # @default -- `{{ .Release.Name }}`
 # @section -- Parameters
 applicationName: ""
 
-# -- (string) Override chart version used in helm.sh/chart label. Useful for stable snapshot testing.
+# -- (string, null) Override chart version used in helm.sh/chart label. Useful for stable snapshot testing.
 # @default -- `{{ .Chart.Version }}`
 # @ignore
 chartVersionOverride: ""
 
-# -- (object) Additional labels for all resources. Keys and values are evaluated as templates.
+# -- (object, null) Additional labels for all resources. Keys and values are evaluated as templates.
 # @section -- Parameters
 additionalLabels:
   # example.com/organization: organization-name
@@ -31,7 +31,7 @@ cronJob:
   # -- (bool) Deploy CronJob resources.
   # @section -- CronJob Parameters
   enabled: false
-  # -- (object) Map of CronJob resources.
+  # -- (object, null) Map of CronJob resources.
   # Key will be used as a name suffix for the CronJob. Value is the CronJob configuration.
   # See values for more details.
   # @section -- CronJob Parameters
@@ -95,7 +95,7 @@ job:
   # -- (bool) Deploy Job resources.
   # @section -- Job Parameters
   enabled: false
-  # -- (object) Map of Job resources.
+  # -- (object, null) Map of Job resources.
   # Key will be used as a name suffix for the Job. Value is the Job configuration.
   # See values for more details.
   # @section -- Job Parameters
@@ -160,16 +160,16 @@ deployment:
   # -- (bool) Enable Deployment.
   # @section -- Deployment Parameters
   enabled: true
-  # -- (object) Additional labels for Deployment.
+  # -- (object, null) Additional labels for Deployment.
   # @section -- Deployment Parameters
   additionalLabels:
-  # -- (object) Additional pod labels which are used in Service's Label Selector.
+  # -- (object, null) Additional pod labels which are used in Service's Label Selector.
   # @section -- Deployment Parameters
   podLabels:
-  # -- (object) Annotations for Deployment.
+  # -- (object, null) Annotations for Deployment.
   # @section -- Deployment Parameters
   annotations:
-  # -- (object) Additional pod annotations.
+  # -- (object, null) Additional pod annotations.
   # @section -- Deployment Parameters
   additionalPodAnnotations:
   strategy:
@@ -182,7 +182,7 @@ deployment:
   # -- (bool) Reload deployment if attached Secret/ConfigMap changes.
   # @section -- Deployment Parameters
   reloadOnChange: true
-  # -- (object) Select the node where the pods should be scheduled.
+  # -- (object, null) Select the node where the pods should be scheduled.
   # @section -- Deployment Parameters
   nodeSelector:
   # -- (list) Mapping between IP and hostnames that will be injected as entries in the pod's hosts files.
@@ -196,14 +196,14 @@ deployment:
   #   hostnames:
   #   - "foo.remote"
   #   - "bar.remote"
-  # -- (object) Add init containers to the pods.
+  # -- (object, null) Add init containers to the pods.
   # @section -- Deployment Parameters
   initContainers:
     # init-something:
     #   image: busybox
     #   imagePullPolicy: IfNotPresent
     #   command: ['/bin/sh']
-  # -- (object) Configuration details for fluentdConfigurations.
+  # -- (object, null) Configuration details for fluentdConfigurations.
   # Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>.
   # @section -- Deployment Parameters
   fluentdConfigAnnotations:
@@ -223,7 +223,7 @@ deployment:
   # @section -- Deployment Parameters
   imagePullSecrets: []
   #  - name: docker-pull
-  # -- (object) Mount environment variables from ConfigMap or Secret to the pod.
+  # -- (object, null) Mount environment variables from ConfigMap or Secret to the pod.
   # Use `nameSuffix` for resources managed by this chart (name will be prefixed with application name),
   # or `name` to reference an existing external ConfigMap or Secret not managed by this chart.
   # See the README "Consuming environment variable in application chart" section for more details.
@@ -246,7 +246,7 @@ deployment:
   #  external-configmap:
   #    type: configmap
   #    name: my-existing-configmap
-  # -- (object) Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details.
+  # -- (object, null) Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details.
   # @section -- Deployment Parameters
   env:
   #  ENVIRONMENT:
@@ -256,7 +256,7 @@ deployment:
   #        configMapKeyRef:
   #           name: config
   #           key: frequency
-  # -- (object) Volumes to be added to the pod.
+  # -- (object, null) Volumes to be added to the pod.
   # Key is the name of the volume. Value is the volume definition.
   # @section -- Deployment Parameters
   volumes:
@@ -269,7 +269,7 @@ deployment:
     # persistent-volume-name:
     #   persistentVolumeClaim:
     #     claimName: claim-name
-  # -- (object) Mount path for Volumes.
+  # -- (object, null) Mount path for Volumes.
   # Key is the name of the volume. Value is the volume mount definition.
   # @section -- Deployment Parameters
   volumeMounts:
@@ -278,10 +278,10 @@ deployment:
     #    subPath: szy
     # volume-name-2:
     #    mountPath: path-2
-  # -- (string) Define the priority class for the pod.
+  # -- (string, null) Define the priority class for the pod.
   # @section -- Deployment Parameters
   priorityClassName: ""
-  # -- (string) Set the runtimeClassName for the deployment's pods.
+  # -- (string, null) Set the runtimeClassName for the deployment's pods.
   # @section -- Deployment Parameters
   runtimeClassName: ""
   # -- (list) Taint tolerations for the pods.
@@ -291,7 +291,7 @@ deployment:
     #   operator: "Equal"
     #   value: "app"
     #   effect: "NoSchedule"
-  # -- (object) Affinity for the pods.
+  # -- (object, null) Affinity for the pods.
   # @section -- Deployment Parameters
   affinity:
   #  nodeAffinity:
@@ -339,19 +339,19 @@ deployment:
     # -- (string) Image pull policy.
     # @section -- Deployment Parameters
     pullPolicy: IfNotPresent
-  # -- (object) DNS config for the pods.
+  # -- (object, null) DNS config for the pods.
   # @section -- Deployment Parameters
   dnsConfig:
     # options:
     # - name: ndots
     #   value: '1'
-  # -- (string) DNS Policy.
+  # -- (string, null) DNS Policy.
   # @section -- Deployment Parameters
   dnsPolicy: ""
   # -- (bool) Enable Kubernetes service links.
   # @section -- Deployment Parameters
   enableServiceLinks: true
-  # -- (object) Startup probe.
+  # -- (object, null) Startup probe.
   # @default -- See below
   # Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc
   # @section -- Deployment Parameters
@@ -384,7 +384,7 @@ deployment:
     # @section -- Deployment Parameters
     grpc: {}
 
-  # -- (object) Readiness probe.
+  # -- (object, null) Readiness probe.
   # @default -- See below
   # Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc
   # @section -- Deployment Parameters
@@ -417,7 +417,7 @@ deployment:
     # @section -- Deployment Parameters
     grpc: {}
 
-  # -- (object) Liveness probe.
+  # -- (object, null) Liveness probe.
   # @default -- See below
   # Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc
   # @section -- Deployment Parameters
@@ -458,7 +458,7 @@ deployment:
     # requests:
     #   memory: 128Mi
     #   cpu: 0.1
-  # -- (object) Security Context at Container Level.
+  # -- (object, null) Security Context at Container Level.
   # @section -- Deployment Parameters
   containerSecurityContext:
     readOnlyRootFilesystem: true
@@ -480,7 +480,7 @@ deployment:
     # It can be useful when an ingress is enabled for the application.
     # @section -- Deployment Parameters
     disableTLSArg: false
-  # -- (object) Security Context for the pod.
+  # -- (object, null) Security Context for the pod.
   # @section -- Deployment Parameters
   securityContext:
     # fsGroup: 2000
@@ -535,7 +535,7 @@ persistence:
   # -- (string) If `persistence.mountPVC` is enabled, where to mount the volume in the containers.
   # @section -- Deployment Parameters
   mountPath: "/"
-  # -- (string) Name of the PVC.
+  # -- (string, null) Name of the PVC.
   # @default -- `{{ include "application.name" $ }}-data`
   # @section -- Deployment Parameters
   name: ""
@@ -549,21 +549,21 @@ persistence:
   #   set, choosing the default provisioner.
   # @section -- Deployment Parameters
   storageClass: null
-  # -- (object) Additional labels for persistent volume.
+  # -- (object, null) Additional labels for persistent volume.
   # @section -- Deployment Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for persistent volume.
+  # -- (object, null) Annotations for persistent volume.
   # @section -- Deployment Parameters
   annotations:
     # "helm.sh/resource-policy": keep
   # -- (string) Size of the persistent volume.
   # @section -- Deployment Parameters
   storageSize: 8Gi
-  # -- (string) PVC Volume Mode.
+  # -- (string, null) PVC Volume Mode.
   # @section -- Deployment Parameters
   volumeMode: ""
-  # -- (string) Name of the volume.
+  # -- (string, null) Name of the volume.
   # @section -- Deployment Parameters
   volumeName: ""
 
@@ -571,10 +571,10 @@ service:
   # -- (bool) Enable Service.
   # @section -- Service Parameters
   enabled: true
-  # -- (object) Additional labels for service.
+  # -- (object, null) Additional labels for service.
   # @section -- Service Parameters
   additionalLabels:
-  # -- (object) Annotations for service.
+  # -- (object, null) Annotations for service.
   # @section -- Service Parameters
   annotations:
     # config.xposer.stakater.com/Domain: stakater.com
@@ -593,15 +593,17 @@ service:
     - port: 8080
       name: http
       protocol: TCP
+      # -- (int, string, null) Target port on pods. Accepts port number or port name (IANA_SVC_NAME).
+      # @section -- Service Parameters
       targetPort: 8080
   # -- (string) Type of service.
   # @section -- Service Parameters
   type: ClusterIP
-  # -- (string) Fixed IP for a ClusterIP service.
+  # -- (string, null) Fixed IP for a ClusterIP service.
   # Set to `None` for an headless service
   # @section -- Service Parameters
   clusterIP:
-  # -- (string) LoadBalancer class name for LoadBalancer type services.
+  # -- (string, null) LoadBalancer class name for LoadBalancer type services.
   # @section -- Service Parameters
   loadBalancerClass:
 
@@ -609,7 +611,7 @@ ingress:
   # -- (bool) Enable Ingress.
   # @section -- Ingress Parameters
   enabled: false
-  # -- (string) Name of the ingress class.
+  # -- (string, null) Name of the ingress class.
   # @section -- Ingress Parameters
   ingressClassName: ""
   hosts:
@@ -620,22 +622,22 @@ ingress:
       - # -- (string) Path.
         # @section -- Ingress Parameters
         path: /
-        # -- (string) Path type.
+        # -- (string, null) Path type.
         # @default -- `ImplementationSpecific`
         # @section -- Ingress Parameters
         pathType:
-        # -- (string) Service name.
+        # -- (string, null) Service name.
         # @default -- `{{ include "application.name" $ }}`
         # @section -- Ingress Parameters
         serviceName:
-        # -- (string) Service port.
+        # -- (string, null) Service port.
         # @default -- `http`
         # @section -- Ingress Parameters
         servicePort:
-  # -- (object) Additional labels for ingress.
+  # -- (object, null) Additional labels for ingress.
   # @section -- Ingress Parameters
   additionalLabels:
-  # -- (object) Annotations for ingress.
+  # -- (object, null) Annotations for ingress.
   # @section -- Ingress Parameters
   annotations:
     # kubernetes.io/ingress.class: external-ingress
@@ -659,14 +661,14 @@ httpRoute:
   parentRefs:
     # - name: my-gateway
     #   sectionName: bar
-  # -- (string) The default Gateway scope to use for this Route.
+  # -- (string, null) The default Gateway scope to use for this Route.
   # If unset (the default) or set to None, the Route will not be attached
   # to any default Gateway; if set, it will be attached to any
   # default Gateway supporting the named scope, subject to the usual rules
   # about which Routes a Gateway is allowed to claim.
   # @section -- HTTPRoute Parameters
   useDefaultGateways:
-  # -- (string) Namespace of the Gateway to attach this HTTPRoute to.
+  # -- (string, null) Namespace of the Gateway to attach this HTTPRoute to.
   # If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute.
   # @section -- HTTPRoute Parameters
   gatewayNamespace: ""
@@ -688,29 +690,31 @@ httpRoute:
             value: /
       backendRefs:
         - name: '{{ include "application.name" $ }}'
+          # -- (int, tpl, null) Port number or template expression for the backend service.
+          # @section -- HTTPRoute Parameters
           port: '{{ (first $.Values.service.ports).port }}'
 
 route:
   # -- (bool) Deploy a Route (OpenShift) resource.
   # @section -- Route Parameters
   enabled: false
-  # -- (object) Additional labels for Route.
+  # -- (object, null) Additional labels for Route.
   # @section -- Route Parameters
   additionalLabels:
-  # -- (object) Annotations for Route.
+  # -- (object, null) Annotations for Route.
   # @section -- Route Parameters
   annotations:
     # kubernetes.io/ingress.class: external-ingress
     # ingress.kubernetes.io/rewrite-target: /
     # ingress.kubernetes.io/force-ssl-redirect: true
-  # -- (string) Explicit host.
+  # -- (string, null) Explicit host.
   # If no host is added then openshift inserts the default hostname.
   # @section -- Route Parameters
   host:
-  # -- (string) Path.
+  # -- (string, null) Path.
   # @section -- Route Parameters
   path:
-  # -- (object) Service port.
+  # -- (object, null) Service port.
   # @section -- Route Parameters
   port:
     targetPort: http
@@ -728,7 +732,7 @@ route:
     # -- (string) TLS insecure termination policy.
     # @section -- Route Parameters
     insecureEdgeTerminationPolicy: Redirect
-  # -- (object) Alternate backend with it's weight.
+  # -- (object, null) Alternate backend with it's weight.
   # @section -- Route Parameters
   alternateBackends:
     # kind: Service
@@ -739,16 +743,16 @@ secretProviderClass:
   # -- (bool) Deploy a [Secrets Store CSI Driver SecretProviderClass](https://secrets-store-csi-driver.sigs.k8s.io/) resource.
   # @section -- SecretProviderClass Parameters
   enabled: false
-  # -- (string) Name of the SecretProviderClass.
+  # -- (string, null) Name of the SecretProviderClass.
   # Required if `secretProviderClass.enabled` is set to `true`.
   # @section -- SecretProviderClass Parameters
   name: ""
-  # -- (string) Name of the provider.
+  # -- (string, null) Name of the provider.
   # Required if `secretProviderClass.enabled` is set to `true`.
   # @section -- SecretProviderClass Parameters
   provider: ""
   # provider: vault
-  # -- (string) Vault Address.
+  # -- (string, null) Vault Address.
   # Required if `secretProviderClass.provider` is set to `vault`.
   # @section -- SecretProviderClass Parameters
   vaultAddress: ""
@@ -758,7 +762,7 @@ secretProviderClass:
   # @section -- SecretProviderClass Parameters
   roleName: ""
   # roleName: example-role
-  # -- (string) Objects definitions.
+  # -- (string, null) Objects definitions.
   # @section -- SecretProviderClass Parameters
   objects:
     # |
@@ -778,21 +782,21 @@ forecastle:
   # -- (bool) Deploy a [ForecastleApp](https://github.com/stakater/Forecastle) resource.
   # @section -- ForecastleApp Parameters
   enabled: false
-  # -- (object) Additional labels for ForecastleApp.
+  # -- (object, null) Additional labels for ForecastleApp.
   # @section -- ForecastleApp Parameters
   additionalLabels:
   # -- (string) Icon URL.
   # @section -- ForecastleApp Parameters
   icon: https://raw.githubusercontent.com/stakater/ForecastleIcons/master/stakater-big.png
-  # -- (string) Application Name.
+  # -- (string, null) Application Name.
   # Required if `forecastle.enabled` is set to `true`.
   # @section -- ForecastleApp Parameters
   displayName: ""
-  # -- (string) Application Group.
+  # -- (string, null) Application Group.
   # @default -- `{{ .Release.Namespace }}`
   # @section -- ForecastleApp Parameters
   group: ""
-  # -- (object) Custom properties.
+  # -- (object, null) Custom properties.
   # @section -- ForecastleApp Parameters
   properties:
     # Owner: foo
@@ -808,18 +812,18 @@ rbac:
     # -- (bool) Specifies whether to create a dedicated service account. If set to `true`, a new service account will be created.
     # @section -- RBAC Parameters
     create: false
-    # -- (string) The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`:
+    # -- (string, null) The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`:
     # If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account ("default") is used.
     # If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used.
     # If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template.
     # If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation.
     # @section -- RBAC Parameters
     name: ""
-    # -- (object) Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account.
+    # -- (object, null) Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account.
     # @section -- RBAC Parameters
     additionalLabels:
       # key: value
-    # -- (object) Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account.
+    # -- (object, null) Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account.
     # @section -- RBAC Parameters
     annotations:
       # key: value
@@ -863,11 +867,11 @@ rbac:
   #     - get
   #     - list
   #     - watch
-  # -- (object) Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources.
+  # -- (object, null) Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources.
   # @section -- RBAC Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources.
+  # -- (object, null) Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources.
   # @section -- RBAC Parameters
   annotations:
     # key: value
@@ -876,15 +880,15 @@ configMap:
   # -- (bool) Deploy additional ConfigMaps.
   # @section -- ConfigMap Parameters
   enabled: false
-  # -- (object) Additional labels for ConfigMaps.
+  # -- (object, null) Additional labels for ConfigMaps.
   # @section -- ConfigMap Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for ConfigMaps.
+  # -- (object, null) Annotations for ConfigMaps.
   # @section -- ConfigMap Parameters
   annotations:
     # key: value
-  # -- (object) List of ConfigMap entries.
+  # -- (object, null) List of ConfigMap entries.
   # Key will be used as a name suffix for the ConfigMap. Value is the ConfigMap content.
   # @section -- ConfigMap Parameters
   files:
@@ -899,15 +903,15 @@ sealedSecret:
   # -- (bool) Deploy [SealedSecret](https://github.com/bitnami-labs/sealed-secrets) resources.
   # @section -- SealedSecret Parameters
   enabled: false
-  # -- (object) Additional labels for SealedSecret.
+  # -- (object, null) Additional labels for SealedSecret.
   # @section -- SealedSecret Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for SealedSecret.
+  # -- (object, null) Annotations for SealedSecret.
   # @section -- SealedSecret Parameters
   annotations:
     # key: value
-  # -- (object) List of SealedSecret entries.
+  # -- (object, null) List of SealedSecret entries.
   # Key will be used as a name suffix for the SealedSecret. Value is the SealedSecret content.
   # @section -- SealedSecret Parameters
   files:
@@ -927,15 +931,15 @@ secret:
   # -- (bool) Deploy additional Secret resources.
   # @section -- Secret Parameters
   enabled: false
-  # -- (object) Additional labels for Secret.
+  # -- (object, null) Additional labels for Secret.
   # @section -- Secret Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for Secret.
+  # -- (object, null) Annotations for Secret.
   # @section -- Secret Parameters
   annotations:
     # key: value
-  # -- (object) List of Secrets entries.
+  # -- (object, null) List of Secrets entries.
   # Key will be used as a name suffix for the Secret.
   # There a three allowed modes:
   # - `data`: Data is base64 encoded by the chart
@@ -964,11 +968,11 @@ serviceMonitor:
   # -- (bool) Deploy a ServiceMonitor (Prometheus Operator) resource.
   # @section -- ServiceMonitor Parameters
   enabled: false
-  # -- (object) Additional labels for ServiceMonitor.
+  # -- (object, null) Additional labels for ServiceMonitor.
   # @section -- ServiceMonitor Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for ServiceMonitor.
+  # -- (object, null) Annotations for ServiceMonitor.
   # @section -- ServiceMonitor Parameters
   annotations:
     # key: value
@@ -983,11 +987,11 @@ autoscaling:
   # -- (bool) Enable Horizontal Pod Autoscaling.
   # @section -- Autoscaling - Horizontal Pod Autoscaling Parameters
   enabled: false
-  # -- (object) Additional labels for HPA.
+  # -- (object, null) Additional labels for HPA.
   # @section -- Autoscaling - Horizontal Pod Autoscaling Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for HPA.
+  # -- (object, null) Annotations for HPA.
   # @section -- Autoscaling - Horizontal Pod Autoscaling Parameters
   annotations:
     # key: value
@@ -1017,18 +1021,18 @@ vpa:
   # -- (bool) Enable Vertical Pod Autoscaling.
   # @section -- VPA - Vertical Pod Autoscaler Parameters
   enabled: false
-  # -- (object) Additional labels for VPA.
+  # -- (object, null) Additional labels for VPA.
   # @section -- VPA - Vertical Pod Autoscaler Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for VPA.
+  # -- (object, null) Annotations for VPA.
   # @section -- VPA - Vertical Pod Autoscaler Parameters
   annotations:
     # key: value
   # -- (list) Container policies for individual containers.
   # @section -- VPA - Vertical Pod Autoscaler Parameters
   containerPolicies: []
-  # -- (object) Update policy.
+  # -- (object, null) Update policy.
   # @section -- VPA - Vertical Pod Autoscaler Parameters
   updatePolicy:
     updateMode: Auto
@@ -1037,11 +1041,11 @@ endpointMonitor:
   # -- (bool) Deploy an [IMC EndpointMonitor](https://github.com/stakater/IngressMonitorController) resource.
   # @section -- EndpointMonitor Parameters
   enabled: false
-  # -- (object) Additional labels for EndpointMonitor.
+  # -- (object, null) Additional labels for EndpointMonitor.
   # @section -- EndpointMonitor Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for EndpointMonitor.
+  # -- (object, null) Annotations for EndpointMonitor.
   # @section -- EndpointMonitor Parameters
   annotations:
     # key: value
@@ -1050,11 +1054,11 @@ certificate:
   # -- (bool) Deploy a [cert-manager Certificate](https://cert-manager.io) resource.
   # @section -- cert-manager Certificate Parameters
   enabled: false
-  # -- (object) Additional labels for Certificate.
+  # -- (object, null) Additional labels for Certificate.
   # @section -- cert-manager Certificate Parameters
   additionalLabels:
     # key: value
-  # -- (object) Annotations for Certificate.
+  # -- (object, null) Annotations for Certificate.
   # @section -- cert-manager Certificate Parameters
   annotations:
     # key: value
@@ -1067,7 +1071,7 @@ certificate:
   # -- (string) The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate.
   # @section -- cert-manager Certificate Parameters
   renewBefore: 720h0m0s # 30d
-  # -- (object) Full X509 name specification for certificate. Keys and values are evaluated as templates.
+  # -- (object, null) Full X509 name specification for certificate. Keys and values are evaluated as templates.
   # @section -- cert-manager Certificate Parameters
   subject:
   #  organizations:
@@ -1167,16 +1171,16 @@ alertmanagerConfig:
   # -- (bool) Deploy an AlertmanagerConfig (Prometheus Operator) resource.
   # @section -- AlertmanagerConfig Parameters
   enabled: false
-  # -- (object) Labels to be picked up by Alertmanager to add it to base config.
+  # -- (object, null) Labels to be picked up by Alertmanager to add it to base config.
   # Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html](OpenShift's AlermanagerConfig documentation) under .spec.alertmanagerConfigSelector.
   # @section -- AlertmanagerConfig Parameters
   selectionLabels:
     alertmanagerConfig: workload
-  # -- (object) AlertmanagerConfig spec.
+  # -- (object, null) AlertmanagerConfig spec.
   # Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html](OpenShift's AlermanagerConfig documentation).
   # @section -- AlertmanagerConfig Parameters
   spec:
-    # -- (object) Route definition for alerts matching the resource’s namespace.
+    # -- (object, null) Route definition for alerts matching the resource’s namespace.
     # It will be added to the generated Alertmanager configuration as a first-level route.
     # @section -- AlertmanagerConfig Parameters
     route:
@@ -1209,7 +1213,7 @@ prometheusRule:
   # -- (bool) Deploy a PrometheusRule (Prometheus Operator) resource.
   # @section -- PrometheusRule Parameters
   enabled: false
-  # -- (object) Additional labels for PrometheusRule.
+  # -- (object, null) Additional labels for PrometheusRule.
   # @section -- PrometheusRule Parameters
   additionalLabels:
     # prometheus: stakater-workload-monitoring
@@ -1233,15 +1237,15 @@ externalSecret:
   # -- (bool) Deploy [ExternalSecret](https://external-secrets.io/latest/) resources.
   # @section -- ExternalSecret Parameters
   enabled: false
-  # -- (object) Additional labels for ExternalSecret.
+  # -- (object, null) Additional labels for ExternalSecret.
   # @section -- ExternalSecret Parameters
   additionalLabels:
   #   key: value
-  # -- (object) Annotations for ExternalSecret.
+  # -- (object, null) Annotations for ExternalSecret.
   # @section -- ExternalSecret Parameters
   annotations:
   #   key: value
-  # -- (object) Default values for the SecretStore.
+  # -- (object, null) Default values for the SecretStore.
   # Can be overriden per ExternalSecret in the `externalSecret.files` object.
   # @section -- ExternalSecret Parameters
   secretStore:
@@ -1255,7 +1259,7 @@ externalSecret:
   # -- (string) RefreshInterval is the amount of time before the values are read again from the SecretStore provider.
   # @section -- ExternalSecret Parameters
   refreshInterval: "1m"
-  # -- (object) List of ExternalSecret entries.
+  # -- (object, null) List of ExternalSecret entries.
   # Key will be used as a name suffix for the ExternalSecret.
   # There a two allowed modes:
   # - `data`: Data defines the connection between the Kubernetes Secret keys and the Provider data
@@ -1282,11 +1286,11 @@ networkPolicy:
   # -- (bool) Enable Network Policy.
   # @section -- NetworkPolicy Parameters
   enabled: false
-  # -- (object) Additional labels for Network Policy.
+  # -- (object, null) Additional labels for Network Policy.
   # @section -- NetworkPolicy Parameters
   additionalLabels:
   #   key: value
-  # -- (object) Annotations for Network Policy.
+  # -- (object, null) Annotations for Network Policy.
   # @section -- NetworkPolicy Parameters
   annotations:
   #   key: value
@@ -1321,10 +1325,10 @@ pdb:
   # -- (bool) Enable Pod Disruption Budget.
   # @section -- PodDisruptionBudget Parameters
   enabled: false
-  # -- (int) Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. "25%").
+  # -- (int, string, null) Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. "25%").
   # @section -- PodDisruptionBudget Parameters
   minAvailable: 1
-  # -- (int) Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. "25%").
+  # -- (int, string, null) Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. "25%").
   # @section -- PodDisruptionBudget Parameters
   maxUnavailable:
   # maxUnavailable: 1
@@ -1333,15 +1337,15 @@ grafanaDashboard:
   # -- (bool) Deploy [GrafanaDashboard](https://github.com/grafana/grafana-operator) resources.
   # @section -- GrafanaDashboard Parameters
   enabled: false
-  # -- (object) Additional labels for GrafanaDashboard.
+  # -- (object, null) Additional labels for GrafanaDashboard.
   # @section -- GrafanaDashboard Parameters
   additionalLabels:
     # grafanaDashboard: grafana-operator
-  # -- (object) Annotations for GrafanaDashboard.
+  # -- (object, null) Annotations for GrafanaDashboard.
   # @section -- GrafanaDashboard Parameters
   annotations:
     # key: value
-  # -- (object) List of GrafanaDashboard entries.
+  # -- (object, null) List of GrafanaDashboard entries.
   # Key will be used as a name suffix for the GrafanaDashboard. Value is the GrafanaDashboard content.
   # According to GrafanaDashboard behavior, `url` field takes precedence on the `json` field.
   # @section -- GrafanaDashboard Parameters
@@ -1370,15 +1374,15 @@ backup:
   # -- (bool) Deploy a [Velero/OADP Backup](https://velero.io/docs/main/api-types/backup/) resource.
   # @section -- Backup Parameters
   enabled: false
-  # -- (string) Namespace for Backup.
+  # -- (string, null) Namespace for Backup.
   # @default -- `{{ .Release.Namespace }}`
   # @section -- Backup Parameters
   namespace:
-  # -- (object) Additional labels for Backup.
+  # -- (object, null) Additional labels for Backup.
   # @section -- Backup Parameters
   additionalLabels:
     # grafanaDashboard: grafana-operator
-  # -- (object) Annotations for Backup.
+  # -- (object, null) Annotations for Backup.
   # @section -- Backup Parameters
   annotations:
     # key: value
@@ -1388,7 +1392,7 @@ backup:
   # -- (bool) Whether to take snapshots of persistent volumes as part of the backup.
   # @section -- Backup Parameters
   snapshotVolumes: true
-  # -- (string) Name of the backup storage location where the backup should be stored.
+  # -- (string, null) Name of the backup storage location where the backup should be stored.
   # @section -- Backup Parameters
   storageLocation:
   # -- (string) How long the Backup should be retained for.
@@ -1406,7 +1410,7 @@ backup:
   # @section -- Backup Parameters
   excludedResources:
 
-# -- (list) Extra K8s manifests to deploy.
+# -- (list, object, null) Extra K8s manifests to deploy.
 # Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are evaluated as templates.
 # @section -- Parameters
 extraObjects:

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 prek = "0.4.3"
 helm = "4.2.0"
 helm-docs = "1.14.2"
-"github:dadav/helm-schema" = "0.23.3"
+"github:dadav/helm-schema" = "0.23.4"
 "ubi:helm-unittest/helm-unittest" = { version = "1.1.0", exe = "untt", rename_exe = "helm-unittest" }
 
 [tasks.set-version]

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,6 @@ prek = "0.4.1"
 helm = "4.2.0"
 helm-docs = "1.14.2"
 "github:dadav/helm-schema" = "0.23.3"
-jq = "1.8.1"
 "ubi:helm-unittest/helm-unittest" = { version = "1.1.0", exe = "untt", rename_exe = "helm-unittest" }
 
 [tasks.set-version]
@@ -35,29 +34,6 @@ helm-schema \\
   --append-newline \\
   --skip-auto-generation required \\
   --skip-auto-generation additionalProperties
-
-tmp="$(mktemp)"
-# helm-schema infers types too strictly from defaults:
-# - optional string fields need "null" added
-# - httpRoute port is templated then casted to int so it accepts both int and string
-# - service targetPort and pdb min/maxUnavailable are IntOrString in Kubernetes
-# - extraObjects can be list or object
-jq '
-  walk(
-    if type == "object" and (.default | type) == "string" and (.type | type) == "string" then
-      .type = [.type, "null"]
-    else
-      .
-    end
-  )
-  | .properties.httpRoute.properties.rules.items.anyOf[].properties.backendRefs.items.anyOf[].properties.port.type = ["integer", "string", "null"]
-  | .properties.service.properties.ports.items.anyOf[].properties.targetPort.type = ["integer", "string", "null"]
-  | .properties.pdb.properties.minAvailable.type = ["integer", "string", "null"]
-  | .properties.pdb.properties.maxUnavailable.type = ["integer", "string", "null"]
-  | .properties.extraObjects.type = ["object", "array", "null"]
-' \\
-  application/values.schema.json > "$tmp"
-mv "$tmp" application/values.schema.json
 """
 
 [tasks.generate]

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 prek = "0.4.3"
 helm = "4.2.0"
 helm-docs = "1.14.2"
-"github:dadav/helm-schema" = "0.23.2"
+"github:dadav/helm-schema" = "0.23.3"
 jq = "1.8.1"
 "ubi:helm-unittest/helm-unittest" = { version = "1.1.0", exe = "untt", rename_exe = "helm-unittest" }
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 prek = "0.4.1"
 helm = "4.2.0"
 helm-docs = "1.14.2"
-"github:dadav/helm-schema" = "0.23.2"
+"github:dadav/helm-schema" = "0.23.3"
 jq = "1.8.1"
 "ubi:helm-unittest/helm-unittest" = { version = "1.1.0", exe = "untt", rename_exe = "helm-unittest" }
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,6 @@ prek = "0.4.3"
 helm = "4.2.0"
 helm-docs = "1.14.2"
 "github:dadav/helm-schema" = "0.23.3"
-jq = "1.8.1"
 "ubi:helm-unittest/helm-unittest" = { version = "1.1.0", exe = "untt", rename_exe = "helm-unittest" }
 
 [tasks.set-version]
@@ -35,29 +34,6 @@ helm-schema \\
   --append-newline \\
   --skip-auto-generation required \\
   --skip-auto-generation additionalProperties
-
-tmp="$(mktemp)"
-# helm-schema infers types too strictly from defaults:
-# - optional string fields need "null" added
-# - httpRoute port is templated then casted to int so it accepts both int and string
-# - service targetPort and pdb min/maxUnavailable are IntOrString in Kubernetes
-# - extraObjects can be list or object
-jq '
-  walk(
-    if type == "object" and (.default | type) == "string" and (.type | type) == "string" then
-      .type = [.type, "null"]
-    else
-      .
-    end
-  )
-  | .properties.httpRoute.properties.rules.items.anyOf[].properties.backendRefs.items.anyOf[].properties.port.type = ["integer", "string", "null"]
-  | .properties.service.properties.ports.items.anyOf[].properties.targetPort.type = ["integer", "string", "null"]
-  | .properties.pdb.properties.minAvailable.type = ["integer", "string", "null"]
-  | .properties.pdb.properties.maxUnavailable.type = ["integer", "string", "null"]
-  | .properties.extraObjects.type = ["object", "array", "null"]
-' \\
-  application/values.schema.json > "$tmp"
-mv "$tmp" application/values.schema.json
 """
 
 [tasks.generate]


### PR DESCRIPTION
## Summary

- Replace `jq` post-processing in `gen-helm-schema` with native comma-separated type hints in `values.yaml`
- Optional fields with empty defaults now declare nullability inline (e.g. `(string, null)`, `(object, null)`)
- IntOrString fields use `(int, string, null)`, extraObjects uses `(list, object, null)`
- All fields with null YAML defaults now include `null` in their type annotation (lists, ints, bools, strings)
- Remove `jq` tool dependency from `mise.toml`

## Test plan

- [x] Run `mise gen-helm-schema` and verify no warnings about `null` type
- [x] Run `mise unit-test` : all 361 tests pass
- [x] Compare generated `values.schema.json` against previous output
- [x] Run `mise lint`