### PR TITLE
feat: add Gateway API ListenerSet template

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | httpRoute.rules | list | `[{"backendRefs":[{"name":"{{ include \"application.name\" $ }}","port":"{{ (first $.Values.service.ports).port }}"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. Keys and values are evaluated as templates. |
 | httpRoute.rules[0].backendRefs[0].port | int, tpl, null | `"{{ (first $.Values.service.ports).port }}"` | Port number or template expression for the backend service. |
 
+### ListenerSet Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| listenerSet.enabled | bool | `false` | Enable ListenerSet (Gateway API). |
+| listenerSet.listeners | list, null | `nil` | Logical endpoints that are bound on this referenced parent Gateway's addresses. Keys and values are evaluated as templates. |
+| listenerSet.parentRef | object, null | `nil` | Parent Gateway reference for the ListenerSet. Keys and values are evaluated as templates. |
+| listenerSet.additionalLabels | object | `{}` | Additional labels for ListenerSet. |
+| listenerSet.annotations | object | `{}` | Annotations for ListenerSet. |
+
 ### Route Parameters
 
 | Key | Type | Default | Description |

--- a/application/templates/listenerset.yaml
+++ b/application/templates/listenerset.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.listenerSet .Values.listenerSet.enabled -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") }}
+{{- fail "There is no Gateway API resource definitions in the target cluster!" }}
+{{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ template "application.name" . }}
+  namespace: {{ include "application.namespace" . }}
+  labels:
+    {{- include "application.labels" $ | nindent 4 }}
+    {{- if .Values.listenerSet.additionalLabels }}
+      {{ toYaml .Values.listenerSet.additionalLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.listenerSet.annotations }}
+  annotations: {{- toYaml .Values.listenerSet.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  listeners: {{- include "application.tplvalues.render" ( dict "value" .Values.listenerSet.listeners "context" $ ) | nindent 4 }}
+  parentRef: {{- include "application.tplvalues.render" ( dict "value" .Values.listenerSet.parentRef "context" $ ) | nindent 4 }}
+{{- end }}

--- a/application/tests/listenerset_test.yaml
+++ b/application/tests/listenerset_test.yaml
@@ -1,0 +1,237 @@
+suite: APIGateway-ListenerSet
+
+templates:
+  - listenerset.yaml
+
+tests:
+  - it: does not render when listenerSet is not enabled
+    set:
+      listenerSet:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when Gateway API is not available
+    set:
+      listenerSet:
+        enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    asserts:
+      - failedTemplate:
+          errorMessage: "There is no Gateway API resource definitions in the target cluster!"
+
+  - it: renders a basic ListenerSet with minimal configuration
+    set:
+      applicationName: "my-app"
+      listenerSet:
+        enabled: true
+        parentRef:
+          name: my-gateway
+        listeners:
+          - name: http
+            protocol: HTTP
+            port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ListenerSet
+      - equal:
+          path: metadata.name
+          value: my-app
+      - equal:
+          path: spec.parentRef.name
+          value: my-gateway
+      - equal:
+          path: spec.listeners[0].name
+          value: http
+      - equal:
+          path: spec.listeners[0].protocol
+          value: HTTP
+      - equal:
+          path: spec.listeners[0].port
+          value: 80
+
+  - it: renders ListenerSet with additional labels
+    set:
+      listenerSet:
+        enabled: true
+        additionalLabels:
+          custom: label
+        parentRef:
+          name: my-gateway
+        listeners:
+          - name: http
+            protocol: HTTP
+            port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: metadata.labels.custom
+          value: label
+
+  - it: renders ListenerSet with annotations
+    set:
+      listenerSet:
+        enabled: true
+        parentRef:
+          name: my-gateway
+        annotations:
+          custom: annotation
+        listeners:
+          - name: http
+            protocol: HTTP
+            port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: metadata.annotations.custom
+          value: annotation
+
+  - it: renders ListenerSet with custom gatewayName and gatewayNamespace
+    set:
+      listenerSet:
+        enabled: true
+        parentRef:
+          name: custom-gateway
+          namespace: custom-ns
+        listeners:
+          - name: http
+            protocol: HTTP
+            port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.parentRef.name
+          value: custom-gateway
+      - equal:
+          path: spec.parentRef.namespace
+          value: custom-ns
+
+  - it: renders ListenerSet with a custom parentRef kind and group
+    set:
+      listenerSet:
+        enabled: true
+        parentRef:
+          name: my-gateway
+          kind: Gateway
+          group: gateway.networking.k8s.io
+        listeners:
+          - name: http
+            protocol: HTTP
+            port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.parentRef.kind
+          value: Gateway
+      - equal:
+          path: spec.parentRef.group
+          value: gateway.networking.k8s.io
+
+  - it: renders ListenerSet with multiple listeners
+    set:
+      listenerSet:
+        parentRef:
+          name: my-gateway
+        enabled: true
+        listeners:
+          - name: http
+            protocol: HTTP
+            port: 80
+          - name: https
+            protocol: HTTPS
+            port: 443
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.listeners[0].name
+          value: http
+      - equal:
+          path: spec.listeners[0].port
+          value: 80
+      - equal:
+          path: spec.listeners[1].name
+          value: https
+      - equal:
+          path: spec.listeners[1].port
+          value: 443
+
+  - it: renders ListenerSet with a TLS listener
+    set:
+      applicationName: "tls-listener"
+      listenerSet:
+        enabled: true
+        parentRef:
+          name: example-gateway
+        listeners:
+          - name: second
+            hostname: second.foo.com
+            protocol: HTTPS
+            port: 443
+            tls:
+              mode: Terminate
+              certificateRefs:
+                - kind: Secret
+                  group: ""
+                  name: second-workload-cert
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ListenerSet
+      - equal:
+          path: metadata.name
+          value: tls-listener
+      - equal:
+          path: spec.parentRef.name
+          value: example-gateway
+      - equal:
+          path: spec.listeners[0].hostname
+          value: second.foo.com
+      - equal:
+          path: spec.listeners[0].tls.mode
+          value: Terminate
+      - equal:
+          path: spec.listeners[0].tls.certificateRefs[0].name
+          value: second-workload-cert
+
+  - it: renders ListenerSet with parentRef name using template expression
+    set:
+      applicationName: "test-app"
+      listenerSet:
+        enabled: true
+        parentRef:
+          name: '{{ include "application.name" $ }}'
+        listeners:
+          - name: http
+            protocol: HTTP
+            port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.parentRef.name
+          value: test-app
+      - isKind:
+          of: ListenerSet

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1915,6 +1915,51 @@
       "title": "job",
       "type": "object"
     },
+    "listenerSet": {
+      "properties": {
+        "additionalLabels": {
+          "description": "Additional labels for ListenerSet.",
+          "required": [],
+          "title": "additionalLabels",
+          "type": "object"
+        },
+        "annotations": {
+          "description": "Annotations for ListenerSet.",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable ListenerSet (Gateway API).",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "listeners": {
+          "default": "",
+          "description": "Logical endpoints that are bound on this referenced parent Gateway's addresses. Keys and values are evaluated as templates.",
+          "required": [],
+          "title": "listeners",
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "parentRef": {
+          "default": "",
+          "description": "Parent Gateway reference for the ListenerSet. Keys and values are evaluated as templates.",
+          "required": [],
+          "title": "parentRef",
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "title": "listenerSet",
+      "type": "object"
+    },
     "namespaceOverride": {
       "default": "",
       "description": "Override the namespace for all resources.",

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -694,6 +694,35 @@ httpRoute:
           # @section -- HTTPRoute Parameters
           port: '{{ (first $.Values.service.ports).port }}'
 
+listenerSet:
+  # -- (bool) Enable ListenerSet (Gateway API).
+  # @section -- ListenerSet Parameters
+  enabled: false
+  # -- (list, null) Logical endpoints that are bound on this referenced parent Gateway's addresses. Keys and values are evaluated as templates.
+  # @section -- ListenerSet Parameters
+  listeners:
+    # - name: second
+    #   hostname: second.foo.com
+    #   protocol: HTTPS
+    #   port: 443
+    #   tls:
+    #     mode: Terminate
+    #     certificateRefs:
+    #     - kind: Secret
+    #       group: ""
+    #       name: second-workload-cert
+  # -- (object, null) Parent Gateway reference for the ListenerSet. Keys and values are evaluated as templates.
+  # @section -- ListenerSet Parameters
+  parentRef:
+    # name: my-gateway
+    # namespace: my-namespace
+  # -- (object) Additional labels for ListenerSet.
+  # @section -- ListenerSet Parameters
+  additionalLabels: {}
+  # -- (object) Annotations for ListenerSet.
+  # @section -- ListenerSet Parameters
+  annotations: {}
+
 route:
   # -- (bool) Deploy a Route (OpenShift) resource.
   # @section -- Route Parameters


### PR DESCRIPTION
Adds a ListenerSet template so the chart can attach additional listeners to an existing Gateway, following the Gateway API ListenerSet resource.

Closes #547