### PR TITLE
chore(chart): use example-registry placeholder in tests and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,7 @@ jobs:
           args=()
           if [ -z "$VALUES" ]; then
             args+=(
-              "--set" "deployment.image.repository=registry/example-image"
+              "--set" "deployment.image.repository=example-registry/example-image"
               "--set" "deployment.image.tag=example-tag"
             )
           else

--- a/application/ci/values.yaml
+++ b/application/ci/values.yaml
@@ -28,7 +28,7 @@ deployment:
         - bar.remote
   initContainers:
     init-container:
-      image: registry/example-image:example-tag
+      image: example-registry/example-image:example-tag
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh"]
       resources:
@@ -115,7 +115,7 @@ deployment:
                   - ssd
   automountServiceAccountToken: false
   image:
-    repository: registry/example-image
+    repository: example-registry/example-image
     tag: example-tag
     pullPolicy: IfNotPresent
   startupProbe:
@@ -173,7 +173,7 @@ deployment:
     enabled: false
   additionalContainers:
     - name: sidecar-container
-      image: registry/example-image:example-tag
+      image: example-registry/example-image:example-tag
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh", "-c", "sleep 3600"]
       securityContext:
@@ -413,7 +413,7 @@ cronJob:
       imagePullSecrets:
         - name: nexus-secret
       image:
-        repository: registry/example-image
+        repository: example-registry/example-image
         tag: example-tag
       env:
         KEY:
@@ -466,7 +466,7 @@ job:
       imagePullSecrets:
         - name: nexus-secret
       image:
-        repository: registry/example-image
+        repository: example-registry/example-image
         tag: example-tag@sha256:example-digest
       env:
         KEY:

--- a/application/tests/__snapshot__/common_test.yaml.snap
+++ b/application/tests/__snapshot__/common_test.yaml.snap
@@ -282,7 +282,7 @@ should match snapshot:
                     - secretRef:
                         name: my-existing-secret
                         optional: false
-                  image: registry/example-image:example-tag
+                  image: example-registry/example-image:example-tag
                   name: db-migration
                   resources:
                     limits:
@@ -421,7 +421,7 @@ should match snapshot:
                 - configMapRef:
                     name: application-my-configmap
                     optional: false
-              image: registry/example-image:example-tag
+              image: example-registry/example-image:example-tag
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -492,7 +492,7 @@ should match snapshot:
                 - /bin/sh
                 - -c
                 - sleep 3600
-              image: registry/example-image:example-tag
+              image: example-registry/example-image:example-tag
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 exec:
@@ -539,7 +539,7 @@ should match snapshot:
           initContainers:
             - command:
                 - /bin/sh
-              image: registry/example-image:example-tag
+              image: example-registry/example-image:example-tag
               imagePullPolicy: IfNotPresent
               name: init-container
               resources:
@@ -1405,7 +1405,7 @@ should match snapshot:
                 - secretRef:
                     name: my-existing-secret
                     optional: false
-              image: registry/example-image:example-tag@sha256:example-digest
+              image: example-registry/example-image:example-tag@sha256:example-digest
               name: db-migration
               resources:
                 limits:

--- a/application/tests/cronjob_test.yaml
+++ b/application/tests/cronjob_test.yaml
@@ -202,9 +202,9 @@ tests:
             initContainers:
               example1:
                 name: shouldnotmatter
-                image: example-image:example-tag
+                image: another-example-registry/another-example-image:another-example-tag
               example2:
-                image: example-image:example-tag
+                image: another-example-registry/another-example-image:another-example-tag
     asserts:
       - isNotNull:
           path: spec.jobTemplate.spec.template.spec.initContainers
@@ -212,17 +212,17 @@ tests:
           path: spec.jobTemplate.spec.template.spec.initContainers
           content:
             name: example1
-            image: example-image:example-tag
+            image: another-example-registry/another-example-image:another-example-tag
       - contains:
           path: spec.jobTemplate.spec.template.spec.initContainers
           content:
             name: example2
-            image: example-image:example-tag
+            image: another-example-registry/another-example-image:another-example-tag
       - notContains:
           path: spec.jobTemplate.spec.template.spec.initContainers
           content:
             name: shouldnotmatter
-            image: example-image:example-tag
+            image: another-example-registry/another-example-image:another-example-tag
 
   - it: includes app.kubernetes.io/name label in pod template
     set:
@@ -258,9 +258,9 @@ tests:
     set:
       custom:
         image:
-          repository: custom-image
-          tag: custom-tag
-          digest: sha256:custom-digest
+          repository: another-example-registry/another-example-image
+          tag: another-example-tag
+          digest: sha256:another-example-digest
       cronJob:
         enabled: true
         jobs:
@@ -272,14 +272,14 @@ tests:
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: custom-image:custom-tag@sha256:custom-digest
+          value: another-example-registry/another-example-image:another-example-tag@sha256:another-example-digest
 
   - it: uses image templating (without tag)
     set:
       custom:
         image:
-          repository: custom-image
-          digest: sha256:custom-digest
+          repository: another-example-registry/another-example-image
+          digest: sha256:another-example-digest
       cronJob:
         enabled: true
         jobs:
@@ -291,14 +291,14 @@ tests:
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: custom-image@sha256:custom-digest
+          value: another-example-registry/another-example-image@sha256:another-example-digest
 
   - it: uses image templating (without digest)
     set:
       custom:
         image:
-          repository: custom-image
-          tag: custom-tag
+          repository: another-example-registry/another-example-image
+          tag: another-example-tag
       cronJob:
         enabled: true
         jobs:
@@ -310,13 +310,13 @@ tests:
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: custom-image:custom-tag
+          value: another-example-registry/another-example-image:another-example-tag
 
   - it: uses image templating (without tag and digest)
     set:
       custom:
         image:
-          repository: custom-image
+          repository: another-example-registry/another-example-image
       cronJob:
         enabled: true
         jobs:
@@ -328,7 +328,7 @@ tests:
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: custom-image
+          value: another-example-registry/another-example-image
 
   - it: does not render @null when digest field is omitted
     set:

--- a/application/tests/cronjob_test.yaml
+++ b/application/tests/cronjob_test.yaml
@@ -11,13 +11,13 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: ""
               digest: ""
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: registry/example-image
+          value: example-registry/example-image
 
   - it: fails rendering when job image repository is not given
     set:
@@ -40,13 +40,13 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
               digest: ""
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag
+          value: example-registry/example-image:example-tag
 
   - it: uses digest when defined
     set:
@@ -55,13 +55,13 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: ""
               digest: sha256:example-digest
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: registry/example-image@sha256:example-digest
+          value: example-registry/example-image@sha256:example-digest
 
   - it: uses both tag and digest when given both
     set:
@@ -70,13 +70,13 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
               digest: sha256:example-digest
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag@sha256:example-digest
+          value: example-registry/example-image:example-tag@sha256:example-digest
 
   - it: applies the annotations correctly to the cronjob
     set:
@@ -85,7 +85,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
               digest: sha256:example-digest
             annotations:
@@ -105,7 +105,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
               digest: sha256:example-digest
             additionalPodAnnotations:
@@ -123,7 +123,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             activeDeadlineSeconds: 0
     asserts:
@@ -140,7 +140,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             startingDeadlineSeconds: 0
     asserts:
@@ -157,7 +157,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             activeDeadlineSeconds: 0
             startingDeadlineSeconds: 0
@@ -180,7 +180,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             activeDeadlineSeconds: 300
     asserts:
@@ -197,7 +197,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             initContainers:
               example1:
@@ -231,7 +231,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       applicationName: my-app
     asserts:
@@ -246,7 +246,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       applicationName: my-app
     asserts:
@@ -337,12 +337,12 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag
+          value: example-registry/example-image:example-tag
       - notMatchRegex:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
           pattern: "@null"
@@ -355,7 +355,7 @@ tests:
           example:
             schedule: "0 * * * *"
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       rbac.serviceAccount.create: false
     asserts:
@@ -371,7 +371,7 @@ tests:
           example:
             schedule: "0 * * * *"
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       rbac.serviceAccount.create: true
       rbac.serviceAccount.name: example-sa
@@ -389,7 +389,7 @@ tests:
           example:
             schedule: "0 * * * *"
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       rbac.serviceAccount.create: true
       rbac.serviceAccount.name: ""
@@ -405,7 +405,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - notExists:
@@ -424,7 +424,7 @@ tests:
                 drop:
                   - ALL
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -443,7 +443,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -458,7 +458,7 @@ tests:
           example:
             automountServiceAccountToken: true
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -472,7 +472,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - notExists:
@@ -485,7 +485,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             securityContext:
               fsGroup: 20000
@@ -506,7 +506,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - notExists:
@@ -520,7 +520,7 @@ tests:
           example:
             enableServiceLinks: true
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -535,7 +535,7 @@ tests:
           example:
             enableServiceLinks: false
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -550,7 +550,7 @@ tests:
           example:
             schedule: "0 * * * *"
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               chart-secret:
@@ -573,7 +573,7 @@ tests:
           example:
             schedule: "0 * * * *"
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               chart-configmap:
@@ -596,7 +596,7 @@ tests:
           example:
             schedule: "0 * * * *"
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               external-secret:
@@ -618,7 +618,7 @@ tests:
           example:
             schedule: "0 * * * *"
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               external-configmap:
@@ -640,7 +640,7 @@ tests:
           example:
             schedule: "0 * * * *"
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               optional-secret:

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -4,7 +4,7 @@ templates:
   - deployment.yaml
 
 set:
-  deployment.image.repository: registry/example-image
+  deployment.image.repository: example-registry/example-image
   deployment.image.tag: example-tag
 
 tests:
@@ -30,13 +30,13 @@ tests:
 
   - it: does not fail to render when image tag and digest are not given
     set:
-      deployment.image.repository: registry/example-image
+      deployment.image.repository: example-registry/example-image
       deployment.image.tag: ""
       deployment.image.digest: ""
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image
+          value: example-registry/example-image
 
   - it: fails to render when image repository is not present
     set:
@@ -47,13 +47,13 @@ tests:
 
   - it: uses image tag when given
     set:
-      deployment.image.repository: registry/example-image
+      deployment.image.repository: example-registry/example-image
       deployment.image.tag: example-tag
       deployment.image.digest: ""
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag
+          value: example-registry/example-image:example-tag
       - equal:
           path: metadata.labels["app.kubernetes.io/version"]
           value: example-tag
@@ -68,34 +68,34 @@ tests:
 
   - it: uses image digest when given
     set:
-      deployment.image.repository: registry/example-image
+      deployment.image.repository: example-registry/example-image
       deployment.image.tag: ""
       deployment.image.digest: sha256:example-digest
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image@sha256:example-digest
+          value: example-registry/example-image@sha256:example-digest
       - isNull:
           path: metadata.labels["app.kubernetes.io/version"]
 
   - it: uses both image digest and tag when given both
     set:
-      deployment.image.repository: registry/example-image
+      deployment.image.repository: example-registry/example-image
       deployment.image.tag: example-tag
       deployment.image.digest: sha256:example-digest
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag@sha256:example-digest
+          value: example-registry/example-image:example-tag@sha256:example-digest
 
   - it: does not render @null when digest field is omitted
     set:
-      deployment.image.repository: registry/example-image
+      deployment.image.repository: example-registry/example-image
       deployment.image.tag: example-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag
+          value: example-registry/example-image:example-tag
       - notMatchRegex:
           path: spec.template.spec.containers[0].image
           pattern: "@null"

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -248,9 +248,9 @@ tests:
     set:
       custom:
         image:
-          repository: custom-image
-          tag: custom-tag
-          digest: sha256:custom-digest
+          repository: another-example-registry/another-example-image
+          tag: another-example-tag
+          digest: sha256:another-example-digest
       deployment:
         image:
           repository: "{{ .Values.custom.image.repository }}"
@@ -259,14 +259,14 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-image:custom-tag@sha256:custom-digest
+          value: another-example-registry/another-example-image:another-example-tag@sha256:another-example-digest
 
   - it: uses image templating (without tag)
     set:
       custom:
         image:
-          repository: custom-image
-          digest: sha256:custom-digest
+          repository: another-example-registry/another-example-image
+          digest: sha256:another-example-digest
       deployment:
         image:
           repository: "{{ .Values.custom.image.repository }}"
@@ -275,14 +275,14 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-image@sha256:custom-digest
+          value: another-example-registry/another-example-image@sha256:another-example-digest
 
   - it: uses image templating (without digest)
     set:
       custom:
         image:
-          repository: custom-image
-          tag: custom-tag
+          repository: another-example-registry/another-example-image
+          tag: another-example-tag
       deployment:
         image:
           repository: "{{ .Values.custom.image.repository }}"
@@ -291,13 +291,13 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-image:custom-tag
+          value: another-example-registry/another-example-image:another-example-tag
 
   - it: uses image templating (without tag and digest)
     set:
       custom:
         image:
-          repository: custom-image
+          repository: another-example-registry/another-example-image
       deployment:
         image:
           repository: "{{ .Values.custom.image.repository }}"
@@ -306,4 +306,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-image
+          value: another-example-registry/another-example-image

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -11,13 +11,13 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: ""
               digest: ""
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image
+          value: example-registry/example-image
 
   - it: fails rendering when job image repository is not given
     set:
@@ -40,13 +40,13 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
               digest: ""
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag
+          value: example-registry/example-image:example-tag
 
   - it: uses digest when defined
     set:
@@ -55,13 +55,13 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: ""
               digest: sha256:example-digest
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image@sha256:example-digest
+          value: example-registry/example-image@sha256:example-digest
 
   - it: uses both tag and digest when given both
     set:
@@ -70,13 +70,13 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
               digest: sha256:example-digest
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag@sha256:example-digest
+          value: example-registry/example-image:example-tag@sha256:example-digest
 
   - it: applies the annotations correctly on the job
     set:
@@ -85,7 +85,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
               digest: sha256:example-digest
             annotations:
@@ -105,7 +105,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
               digest: sha256:example-digest
             additionalPodAnnotations:
@@ -123,7 +123,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             activeDeadlineSeconds: 0
     asserts:
@@ -140,7 +140,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             startingDeadlineSeconds: 0
     asserts:
@@ -157,7 +157,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             activeDeadlineSeconds: 0
             startingDeadlineSeconds: 0
@@ -180,7 +180,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             activeDeadlineSeconds: 300
     asserts:
@@ -197,7 +197,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             initContainers:
               example1:
@@ -231,7 +231,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       applicationName: my-app
     asserts:
@@ -246,7 +246,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       applicationName: my-app
     asserts:
@@ -336,12 +336,12 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry/example-image:example-tag
+          value: example-registry/example-image:example-tag
       - notMatchRegex:
           path: spec.template.spec.containers[0].image
           pattern: "@null"
@@ -353,7 +353,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       rbac.serviceAccount.create: false
     asserts:
@@ -368,7 +368,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       rbac.serviceAccount.create: true
       rbac.serviceAccount.name: example-sa
@@ -385,7 +385,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
       rbac.serviceAccount.create: true
       rbac.serviceAccount.name: ""
@@ -401,7 +401,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - notExists:
@@ -420,7 +420,7 @@ tests:
                 drop:
                   - ALL
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -439,7 +439,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -454,7 +454,7 @@ tests:
           example:
             automountServiceAccountToken: true
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -468,7 +468,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - notExists:
@@ -481,7 +481,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             securityContext:
               fsGroup: 20000
@@ -502,7 +502,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - notExists:
@@ -516,7 +516,7 @@ tests:
           example:
             enableServiceLinks: true
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -531,7 +531,7 @@ tests:
           example:
             enableServiceLinks: false
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
     asserts:
       - equal:
@@ -545,7 +545,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               chart-secret:
@@ -567,7 +567,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               chart-configmap:
@@ -589,7 +589,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               external-secret:
@@ -610,7 +610,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               external-configmap:
@@ -631,7 +631,7 @@ tests:
         jobs:
           example:
             image:
-              repository: registry/example-image
+              repository: example-registry/example-image
               tag: example-tag
             envFrom:
               optional-secret:

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -202,9 +202,9 @@ tests:
             initContainers:
               example1:
                 name: shouldnotmatter
-                image: example-image:example-tag
+                image: another-example-registry/another-example-image:another-example-tag
               example2:
-                image: example-image:example-tag
+                image: another-example-registry/another-example-image:another-example-tag
     asserts:
       - isNotNull:
           path: spec.template.spec.initContainers
@@ -212,17 +212,17 @@ tests:
           path: spec.template.spec.initContainers
           content:
             name: example1
-            image: example-image:example-tag
+            image: another-example-registry/another-example-image:another-example-tag
       - contains:
           path: spec.template.spec.initContainers
           content:
             name: example2
-            image: example-image:example-tag
+            image: another-example-registry/another-example-image:another-example-tag
       - notContains:
           path: spec.template.spec.initContainers
           content:
             name: shouldnotmatter
-            image: example-image:example-tag
+            image: another-example-registry/another-example-image:another-example-tag
 
   - it: includes app.kubernetes.io/name label in pod template
     set:
@@ -258,9 +258,9 @@ tests:
     set:
       custom:
         image:
-          repository: custom-image
-          tag: custom-tag
-          digest: sha256:custom-digest
+          repository: another-example-registry/another-example-image
+          tag: another-example-tag
+          digest: sha256:another-example-digest
       job:
         enabled: true
         jobs:
@@ -272,13 +272,13 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-image:custom-tag@sha256:custom-digest
+          value: another-example-registry/another-example-image:another-example-tag@sha256:another-example-digest
   - it: uses image templating (without tag)
     set:
       custom:
         image:
-          repository: custom-image
-          digest: sha256:custom-digest
+          repository: another-example-registry/another-example-image
+          digest: sha256:another-example-digest
       job:
         enabled: true
         jobs:
@@ -290,14 +290,14 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-image@sha256:custom-digest
+          value: another-example-registry/another-example-image@sha256:another-example-digest
 
   - it: uses image templating (without digest)
     set:
       custom:
         image:
-          repository: custom-image
-          tag: custom-tag
+          repository: another-example-registry/another-example-image
+          tag: another-example-tag
       job:
         enabled: true
         jobs:
@@ -309,13 +309,13 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-image:custom-tag
+          value: another-example-registry/another-example-image:another-example-tag
 
   - it: uses image templating (without tag and digest)
     set:
       custom:
         image:
-          repository: custom-image
+          repository: another-example-registry/another-example-image
       job:
         enabled: true
         jobs:
@@ -327,7 +327,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-image
+          value: another-example-registry/another-example-image
 
   - it: does not render @null when digest field is omitted
     set:

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,10 @@
     "enabled": true
   },
   "ignoreDeps": [
-    "registry/example-image"
+    "example-registry/example-image",
+    "example-registry/another-example-image",
+    "another-example-registry/example-image",
+    "another-example-registry/another-example-image"
   ],
   "customManagers": [
     {


### PR DESCRIPTION
## What

Normalizes the placeholder image values used in tests and CI to the `example-*` family:

- `registry/example-image` becomes `example-registry/example-image` in `application/tests/cronjob_test.yaml`, `deployment_test.yaml`, `job_test.yaml` (suite fixtures and per-test values/asserts), `application/ci/values.yaml`, and the `--set deployment.image.repository=...` install flag in `.github/workflows/ci.yaml`
- Secondary images use a fully distinct `another-example-*` family: the image templating tests (`uses image templating` cases in the three suites) use `another-example-registry/another-example-image` / `another-example-tag` / `another-example-digest` instead of `custom-image` / `custom-tag` / `custom-digest`, and the initContainers tests in the CronJob and Job suites use `another-example-registry/another-example-image:another-example-tag` instead of the bare `example-image:example-tag`
- `application/tests/__snapshot__/common_test.yaml.snap`: regenerated with `helm-unittest -u`
- `renovate.json`: `ignoreDeps` updated to cover the `example-registry` / `another-example-registry` and `example-image` / `another-example-image` combinations

## Why

`registry/` reads like a real path segment. Prefixing it with `example-` makes every component of the placeholder reference (`example-registry/example-image:example-tag`) self-describing as arbitrary. The templating tests need values distinct from the suite fixture so the asserts prove the value flowed through `{{ .Values.custom.image.* }}` rather than the default; the `another-example-*` family makes that distinction obvious at a glance while staying in the same example-style vocabulary, instead of the unrelated `custom-*` naming. It also gives future tests that need a second placeholder container (e.g. the sidecar tests in #593) an established convention.

## Notes

- No template or default values change; this only touches test inputs, CI placeholder values, and the renovate ignore list.
- `openshift/oauth-proxy:latest` in the deployment tests is the chart's actual default, not a placeholder, and is intentionally left as is.

## Validation

- `helm-unittest application`: 382 tests, 37 snapshots, all passing
- `ct lint`: passing
