### PR TITLE
fix(helpers): make backendRef port optional in HTTPRoute rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | httpRoute.additionalLabels | object | `{}` | Additional labels for HTTPRoute. |
 | httpRoute.annotations | object | `{}` | Annotations for HTTPRoute. |
 | httpRoute.rules | list | `[{"backendRefs":[{"name":"{{ include \"application.name\" $ }}","port":"{{ (first $.Values.service.ports).port }}"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. Keys and values are evaluated as templates. |
-| httpRoute.rules[0].backendRefs[0].port | int, tpl, null | `"{{ (first $.Values.service.ports).port }}"` | Port number or template expression for the backend service. |
+| httpRoute.rules[0].backendRefs[0].port | int, tpl, null | `"{{ (first $.Values.service.ports).port }}"` | Port number or template expression for the backend service. Required when the referent is a Kubernetes Service (the default kind); optional for other kinds such as ServiceImport, where it is omitted from the manifest when unset or when a template expression renders empty. |
 
 ### ListenerSet Parameters
 

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -142,11 +142,11 @@ Usage:
   {{- range $rule.backendRefs }}
   {{- $group := .group | default "" }}
   {{- $kind := .kind | default "Service" }}
-  {{- $hasPort := not (kindIs "invalid" .port) }}
+  {{- /* A templated port may render to an empty string; treat it as unset. */}}
+  {{- $hasPort := not (or (kindIs "invalid" .port) (eq (toString .port) "")) }}
   {{- $isKubernetesService := and (eq $group "") (eq $kind "Service") }}
-  {{- $portVal := 0 }}
   {{- if $hasPort }}
-    {{- $portVal = .port | int }}
+    {{- $portVal := .port | int }}
     {{- if or (lt $portVal 1) (gt $portVal 65535) }}
       {{- fail (printf "Invalid port value: %v. Port must be between 1 and 65535" .port) }}
     {{- end }}
@@ -154,8 +154,8 @@ Usage:
     {{- fail (printf "backendRef %q: port is required when the referent is a Kubernetes Service" .name) }}
   {{- end }}
   - name: {{ .name }}
-    {{- if .port }}
-    port: {{ $portVal }}
+    {{- if $hasPort }}
+    port: {{ .port | int }}
     {{- end }}
     {{- if .weight }}
     weight: {{ .weight | int }}

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -140,12 +140,15 @@ Usage:
   {{- if $rule.backendRefs }}
   backendRefs:
   {{- range $rule.backendRefs }}
+  {{- $kind := .kind | default "Service" }}
   {{- $portVal := 0 }}
   {{- if .port }}
     {{- $portVal = .port | int }}
     {{- if or (lt $portVal 1) (gt $portVal 65535) }}
       {{- fail (printf "Invalid port value: %v. Port must be between 1 and 65535" .port) }}
     {{- end }}
+  {{- else if eq $kind "Service" }}
+    {{- fail (printf "backendRef %q: port is required when kind is Service" .name) }}
   {{- end }}
   - name: {{ .name }}
     {{- if .port }}

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -140,12 +140,17 @@ Usage:
   {{- if $rule.backendRefs }}
   backendRefs:
   {{- range $rule.backendRefs }}
-  {{- $portVal := .port | int }}
-  {{- if or (lt $portVal 1) (gt $portVal 65535) }}
-    {{- fail (printf "Invalid port value: %v. Port must be between 1 and 65535" .port) }}
+  {{- $portVal := 0 }}
+  {{- if .port }}
+    {{- $portVal = .port | int }}
+    {{- if or (lt $portVal 1) (gt $portVal 65535) }}
+      {{- fail (printf "Invalid port value: %v. Port must be between 1 and 65535" .port) }}
+    {{- end }}
   {{- end }}
   - name: {{ .name }}
+    {{- if .port }}
     port: {{ $portVal }}
+    {{- end }}
     {{- if .weight }}
     weight: {{ .weight | int }}
     {{- end }}

--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -140,15 +140,18 @@ Usage:
   {{- if $rule.backendRefs }}
   backendRefs:
   {{- range $rule.backendRefs }}
+  {{- $group := .group | default "" }}
   {{- $kind := .kind | default "Service" }}
+  {{- $hasPort := not (kindIs "invalid" .port) }}
+  {{- $isKubernetesService := and (eq $group "") (eq $kind "Service") }}
   {{- $portVal := 0 }}
-  {{- if .port }}
+  {{- if $hasPort }}
     {{- $portVal = .port | int }}
     {{- if or (lt $portVal 1) (gt $portVal 65535) }}
       {{- fail (printf "Invalid port value: %v. Port must be between 1 and 65535" .port) }}
     {{- end }}
-  {{- else if eq $kind "Service" }}
-    {{- fail (printf "backendRef %q: port is required when kind is Service" .name) }}
+  {{- else if $isKubernetesService }}
+    {{- fail (printf "backendRef %q: port is required when the referent is a Kubernetes Service" .name) }}
   {{- end }}
   - name: {{ .name }}
     {{- if .port }}

--- a/application/tests/httproute_test.yaml
+++ b/application/tests/httproute_test.yaml
@@ -283,7 +283,7 @@ tests:
 
   - it: renders HTTPRoute backendRef without a port when kind is not Service
     set:
-      applicationName: "no-port-app"
+      applicationName: no-port-app
       httpRoute:
         enabled: true
         parentRefs:
@@ -310,7 +310,7 @@ tests:
 
   - it: fails when backendRef port is omitted and kind defaults to Service
     set:
-      applicationName: "no-port-default-kind-app"
+      applicationName: no-port-default-kind-app
       httpRoute:
         enabled: true
         parentRefs:
@@ -329,11 +329,11 @@ tests:
         - gateway.networking.k8s.io/v1
     asserts:
       - failedTemplate:
-          errorMessage: 'backendRef "example-service": port is required when kind is Service'
+          errorMessage: 'backendRef "example-service": port is required when the referent is a Kubernetes Service'
 
   - it: fails when backendRef port is omitted and kind is explicitly Service
     set:
-      applicationName: "no-port-explicit-kind-app"
+      applicationName: no-port-explicit-kind-app
       httpRoute:
         enabled: true
         parentRefs:
@@ -353,11 +353,11 @@ tests:
         - gateway.networking.k8s.io/v1
     asserts:
       - failedTemplate:
-          errorMessage: 'backendRef "example-service": port is required when kind is Service'
+          errorMessage: 'backendRef "example-service": port is required when the referent is a Kubernetes Service'
 
   - it: renders HTTPRoute backendRef with a port when port is provided
     set:
-      applicationName: "with-port-app"
+      applicationName: with-port-app
       httpRoute:
         enabled: true
         parentRefs:
@@ -385,7 +385,7 @@ tests:
 
   - it: fails when backendRef port is out of valid range
     set:
-      applicationName: "invalid-port-app"
+      applicationName: invalid-port-app
       httpRoute:
         enabled: true
         parentRefs:
@@ -407,9 +407,58 @@ tests:
       - failedTemplate:
           errorMessage: "Invalid port value: 70000. Port must be between 1 and 65535"
 
+  - it: fails when backendRef port is explicitly 0 for a Service
+    set:
+      applicationName: zero-port-service-app
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 0
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - failedTemplate:
+          errorMessage: "Invalid port value: 0. Port must be between 1 and 65535"
+
+  - it: fails when backendRef port is explicitly 0 for a non-Service kind
+    set:
+      applicationName: zero-port-non-service-app
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                kind: test
+                port: 0
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - failedTemplate:
+          errorMessage: "Invalid port value: 0. Port must be between 1 and 65535"
+
   - it: renders HTTPRoute with mixed backendRefs where only some have a port
     set:
-      applicationName: "mixed-port-app"
+      applicationName: mixed-port-app
       httpRoute:
         enabled: true
         parentRefs:

--- a/application/tests/httproute_test.yaml
+++ b/application/tests/httproute_test.yaml
@@ -281,6 +281,118 @@ tests:
           path: spec.rules[0].filters[0].requestRedirect.port
           value: 443
 
+  - it: renders HTTPRoute backendRef without a port when port is omitted
+    set:
+      applicationName: "no-port-app"
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: example-service
+      - notExists:
+          path: spec.rules[0].backendRefs[0].port
+
+  - it: renders HTTPRoute backendRef with a port when port is provided
+    set:
+      applicationName: "with-port-app"
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 80
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: example-service
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: fails when backendRef port is out of valid range
+    set:
+      applicationName: "invalid-port-app"
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 70000
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - failedTemplate:
+          errorMessage: "Invalid port value: 70000. Port must be between 1 and 65535"
+
+  - it: renders HTTPRoute with mixed backendRefs where only some have a port
+    set:
+      applicationName: "mixed-port-app"
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: 80
+              - name: fallback-service
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: example-service
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+      - equal:
+          path: spec.rules[0].backendRefs[1].name
+          value: fallback-service
+      - notExists:
+          path: spec.rules[0].backendRefs[1].port
+
   - it: renders HTTPRoute with default service port when using template expression
     set:
       applicationName: "test-app"

--- a/application/tests/httproute_test.yaml
+++ b/application/tests/httproute_test.yaml
@@ -491,6 +491,58 @@ tests:
       - notExists:
           path: spec.rules[0].backendRefs[1].port
 
+  - it: treats an empty templated backendRef port as unset for non-Service kinds
+    set:
+      applicationName: empty-tpl-port-app
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                kind: ServiceImport
+                port: '{{ .Values.optionalPort }}'
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: example-service
+      - notExists:
+          path: spec.rules[0].backendRefs[0].port
+
+  - it: fails when a templated backendRef port renders empty for a Service
+    set:
+      applicationName: empty-tpl-port-service-app
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                port: '{{ .Values.optionalPort }}'
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - failedTemplate:
+          errorMessage: 'backendRef "example-service": port is required when the referent is a Kubernetes Service'
+
   - it: renders HTTPRoute with default service port when using template expression
     set:
       applicationName: "test-app"

--- a/application/tests/httproute_test.yaml
+++ b/application/tests/httproute_test.yaml
@@ -281,9 +281,36 @@ tests:
           path: spec.rules[0].filters[0].requestRedirect.port
           value: 443
 
-  - it: renders HTTPRoute backendRef without a port when port is omitted
+  - it: renders HTTPRoute backendRef without a port when kind is not Service
     set:
       applicationName: "no-port-app"
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                kind: ServiceImport
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: example-service
+      - notExists:
+          path: spec.rules[0].backendRefs[0].port
+
+  - it: fails when backendRef port is omitted and kind defaults to Service
+    set:
+      applicationName: "no-port-default-kind-app"
       httpRoute:
         enabled: true
         parentRefs:
@@ -301,11 +328,32 @@ tests:
       apiVersions:
         - gateway.networking.k8s.io/v1
     asserts:
-      - equal:
-          path: spec.rules[0].backendRefs[0].name
-          value: example-service
-      - notExists:
-          path: spec.rules[0].backendRefs[0].port
+      - failedTemplate:
+          errorMessage: 'backendRef "example-service": port is required when kind is Service'
+
+  - it: fails when backendRef port is omitted and kind is explicitly Service
+    set:
+      applicationName: "no-port-explicit-kind-app"
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                kind: Service
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - failedTemplate:
+          errorMessage: 'backendRef "example-service": port is required when kind is Service'
 
   - it: renders HTTPRoute backendRef with a port when port is provided
     set:
@@ -377,6 +425,7 @@ tests:
               - name: example-service
                 port: 80
               - name: fallback-service
+                kind: ServiceImport
     capabilities:
       apiVersions:
         - gateway.networking.k8s.io/v1

--- a/application/tests/httproute_test.yaml
+++ b/application/tests/httproute_test.yaml
@@ -466,6 +466,37 @@ tests:
       - failedTemplate:
           errorMessage: 'backendRef "example-service": port is required when the referent is a Kubernetes Service'
 
+  - it: renders HTTPRoute backendRef without a port for a Service in a non-core group
+    set:
+      applicationName: non-core-service-app
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: example-service
+                kind: Service
+                group: multicluster.example.com
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: example-service
+      - equal:
+          path: spec.rules[0].backendRefs[0].group
+          value: multicluster.example.com
+      - notExists:
+          path: spec.rules[0].backendRefs[0].port
+
   - it: renders HTTPRoute with default service port when using template expression
     set:
       applicationName: "test-app"

--- a/application/tests/httproute_test.yaml
+++ b/application/tests/httproute_test.yaml
@@ -331,58 +331,6 @@ tests:
       - failedTemplate:
           errorMessage: 'backendRef "example-service": port is required when the referent is a Kubernetes Service'
 
-  - it: fails when backendRef port is omitted and kind is explicitly Service
-    set:
-      applicationName: no-port-explicit-kind-app
-      httpRoute:
-        enabled: true
-        parentRefs:
-          - name: my-gateway
-        hostnames:
-          - example.com
-        rules:
-          - matches:
-              - path:
-                  type: PathPrefix
-                  value: /
-            backendRefs:
-              - name: example-service
-                kind: Service
-    capabilities:
-      apiVersions:
-        - gateway.networking.k8s.io/v1
-    asserts:
-      - failedTemplate:
-          errorMessage: 'backendRef "example-service": port is required when the referent is a Kubernetes Service'
-
-  - it: renders HTTPRoute backendRef with a port when port is provided
-    set:
-      applicationName: with-port-app
-      httpRoute:
-        enabled: true
-        parentRefs:
-          - name: my-gateway
-        hostnames:
-          - example.com
-        rules:
-          - matches:
-              - path:
-                  type: PathPrefix
-                  value: /
-            backendRefs:
-              - name: example-service
-                port: 80
-    capabilities:
-      apiVersions:
-        - gateway.networking.k8s.io/v1
-    asserts:
-      - equal:
-          path: spec.rules[0].backendRefs[0].name
-          value: example-service
-      - equal:
-          path: spec.rules[0].backendRefs[0].port
-          value: 80
-
   - it: fails when backendRef port is out of valid range
     set:
       applicationName: invalid-port-app
@@ -423,31 +371,6 @@ tests:
                   value: /
             backendRefs:
               - name: example-service
-                port: 0
-    capabilities:
-      apiVersions:
-        - gateway.networking.k8s.io/v1
-    asserts:
-      - failedTemplate:
-          errorMessage: "Invalid port value: 0. Port must be between 1 and 65535"
-
-  - it: fails when backendRef port is explicitly 0 for a non-Service kind
-    set:
-      applicationName: zero-port-non-service-app
-      httpRoute:
-        enabled: true
-        parentRefs:
-          - name: my-gateway
-        hostnames:
-          - example.com
-        rules:
-          - matches:
-              - path:
-                  type: PathPrefix
-                  value: /
-            backendRefs:
-              - name: example-service
-                kind: test
                 port: 0
     capabilities:
       apiVersions:

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1692,7 +1692,7 @@
                             },
                             "port": {
                               "default": "{{ (first $.Values.service.ports).port }}",
-                              "description": "Port number or template expression for the backend service.",
+                              "description": "Port number or template expression for the backend service. Required when the referent is a Kubernetes Service (the default kind); optional for other kinds such as ServiceImport, where it is omitted from the manifest when unset or when a template expression renders empty.",
                               "required": [],
                               "title": "port",
                               "type": [

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -695,6 +695,9 @@ httpRoute:
       backendRefs:
         - name: '{{ include "application.name" $ }}'
           # -- (int, tpl, null) Port number or template expression for the backend service.
+          # Required when the referent is a Kubernetes Service (the default kind);
+          # optional for other kinds such as ServiceImport, where it is omitted
+          # from the manifest when unset or when a template expression renders empty.
           # @section -- HTTPRoute Parameters
           port: '{{ (first $.Values.service.ports).port }}'
 


### PR DESCRIPTION
The HTTPRoute backendRefs template required `.port` on every backendRef and failed the render if it was missing, but per the Gateway API spec port is optional on a `BackendRef` in general. It is only required when the referent is a core Kubernetes Service.

## What changed

- `port` is validated and rendered only when it is actually set, and left out of the manifest entirely when omitted (e.g. for `kind: ServiceImport` backends).
- Per the Gateway API spec, omitting `port` when the referent is a core Kubernetes Service (`group: ""` and `kind: Service`, the default) still fails the render, now with an explicit message: `backendRef "<name>": port is required when the referent is a Kubernetes Service`.
- A templated port that renders to an empty string (e.g. `port: '{{ .Values.optionalPort }}'` with the value unset) is treated as unset, so the optionality also works with template expressions.
- The `port` documentation in `values.yaml`, README, and `values.schema.json` now states when the field may be omitted.

## Note on the issue repro

The exact reproduction in #602 (no port, kind defaulting to Service) still fails by design, because the Gateway API spec requires port for Service referents and the HTTPRoute CRD would reject the manifest anyway. The difference is that the failure message now explains the actual constraint instead of `Invalid port value: 0`. Backends of any other kind render without a port as the issue expects.

## Tests

Unit tests cover: port omitted for a non-Service kind (rendered without port), port omitted for a Service (explicit failure), empty templated port for both cases, out-of-range and explicit-zero ports, mixed rules where only some backendRefs have a port, and a Service in a non-core group (port optional).

Closes #602
