### PR TITLE
fix(helpers): render zero weight and backendRef filters in HTTPRoute

### DIFF
--- a/application/templates/_helpers.tpl
+++ b/application/templates/_helpers.tpl
@@ -153,11 +153,15 @@ Usage:
   {{- else if $isKubernetesService }}
     {{- fail (printf "backendRef %q: port is required when the referent is a Kubernetes Service" .name) }}
   {{- end }}
+  {{- /* A templated weight may render to an empty string; treat it as unset.
+       An explicit weight of 0 is meaningful (drains the backend), so use a
+       presence check rather than truthiness. */}}
+  {{- $hasWeight := not (or (kindIs "invalid" .weight) (eq (toString .weight) "")) }}
   - name: {{ .name }}
     {{- if $hasPort }}
     port: {{ .port | int }}
     {{- end }}
-    {{- if .weight }}
+    {{- if $hasWeight }}
     weight: {{ .weight | int }}
     {{- end }}
     {{- if .namespace }}
@@ -168,6 +172,9 @@ Usage:
     {{- end }}
     {{- if .group }}
     group: {{ .group }}
+    {{- end }}
+    {{- if .filters }}
+    filters: {{ .filters | toYaml | nindent 6 }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/application/tests/httproute_test.yaml
+++ b/application/tests/httproute_test.yaml
@@ -497,6 +497,91 @@ tests:
       - notExists:
           path: spec.rules[0].backendRefs[0].port
 
+  - it: renders an explicit backendRef weight of 0
+    set:
+      applicationName: zero-weight-app
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - backendRefs:
+              - name: blue
+                port: 80
+                weight: 0
+              - name: green
+                port: 80
+                weight: 100
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 0
+      - equal:
+          path: spec.rules[0].backendRefs[1].weight
+          value: 100
+
+  - it: treats an empty templated backendRef weight as unset
+    set:
+      applicationName: empty-tpl-weight-app
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - backendRefs:
+              - name: example-service
+                port: 80
+                weight: '{{ .Values.optionalWeight }}'
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: example-service
+      - notExists:
+          path: spec.rules[0].backendRefs[0].weight
+
+  - it: renders per-backendRef filters
+    set:
+      applicationName: backend-filters-app
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - backendRefs:
+              - name: example-service
+                port: 80
+                filters:
+                  - type: RequestHeaderModifier
+                    requestHeaderModifier:
+                      add:
+                        - name: x-canary
+                          value: "true"
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].backendRefs[0].filters[0].requestHeaderModifier.add[0].name
+          value: x-canary
+      - equal:
+          path: spec.rules[0].backendRefs[0].filters[0].requestHeaderModifier.add[0].value
+          value: "true"
+
   - it: renders HTTPRoute with default service port when using template expression
     set:
       applicationName: "test-app"


### PR DESCRIPTION
Fixes #613. Follow-up to #603, fixing the two defects in the `application.httpRoute.rules` helper.

## What changed

**`weight: 0` is now rendered.** The renderer guarded weight with a truthiness check (`{{- if .weight }}`), so an explicit `weight: 0` was omitted from the manifest. Since the Gateway API defaults an omitted weight to 1, a backend drained with `weight: 0` kept receiving traffic. The guard is now a presence check, with the same empty-templated-value handling as port.

**Per-backendRef `filters` are passed through.** The backendRef renderer was a field whitelist (`name`, `port`, `weight`, `namespace`, `kind`, `group`), so `HTTPBackendRef.filters` validated against the schema but never reached the manifest. A `toYaml` passthrough now renders it, matching the existing rule-level `matches`/`filters`/`timeouts` handling.

## Validation

- Three new helm-unittest cases: explicit `weight: 0`, empty templated weight treated as unset, and per-backendRef filters passthrough.
- Full suite passes (398 tests, 32 suites) and `helm lint` is clean.
- Confirmed the issue's repro with a live `helm template` render: `weight: 0` and the `RequestHeaderModifier` filter now appear on the rendered backendRef.
