### PR TITLE
feat(security): enforce restricted security context defaults for all workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,11 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.containerSecurityContext | object, null | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
 | deployment.openshiftOAuthProxy.enabled | bool | `false` | Enable [OpenShift OAuth Proxy](https://github.com/openshift/oauth-proxy). |
 | deployment.openshiftOAuthProxy.port | int | `8080` | Port on which application is running inside container. |
+| deployment.openshiftOAuthProxy.containerSecurityContext | object, null | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context for the OAuth Proxy container. |
 | deployment.openshiftOAuthProxy.secretName | string | `"openshift-oauth-proxy-tls"` | Secret name for the OAuth Proxy TLS certificate. |
 | deployment.openshiftOAuthProxy.image | string | `"quay.io/openshift/origin-oauth-proxy:latest@sha256:35967c4d152d7b21167e3ba0aae57e29d3a46a75a738329073ef2227cbc33bde"` | Image for the OAuth Proxy. |
 | deployment.openshiftOAuthProxy.disableTLSArg | bool | `false` | If disabled `--http-address=:8081` will be used instead of `--https-address=:8443`. It can be useful when an ingress is enabled for the application. |
-| deployment.securityContext | object, null | `nil` | Security Context for the pod. |
+| deployment.securityContext | object, null | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context for the pod. |
 | deployment.command | list | `[]` | Command for the app container. |
 | deployment.args | list | `[]` | Args for the app container. |
 | deployment.automountServiceAccountToken | bool | `false` | Mount Service Account token. |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.livenessProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.livenessProbe.grpc | object | `{}` | gRPC probe. |
 | deployment.resources | object | `{}` | Resource limits and requests for the pod. |
-| deployment.containerSecurityContext | object, null | `{"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
+| deployment.containerSecurityContext | object, null | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
 | deployment.openshiftOAuthProxy.enabled | bool | `false` | Enable [OpenShift OAuth Proxy](https://github.com/openshift/oauth-proxy). |
 | deployment.openshiftOAuthProxy.port | int | `8080` | Port on which application is running inside container. |
 | deployment.openshiftOAuthProxy.secretName | string | `"openshift-oauth-proxy-tls"` | Secret name for the OAuth Proxy TLS certificate. |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cronJob.enabled | bool | `false` | Deploy CronJob resources. |
+| cronJob.securityContext | object, null | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Default Security Context at pod level for all CronJobs. Can be overridden per job with `securityContext`. |
+| cronJob.containerSecurityContext | object, null | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Default Security Context at container level for all CronJobs. Can be overridden per job with `containerSecurityContext`. |
 | cronJob.jobs | object, null | `nil` | Map of CronJob resources. Key will be used as a name suffix for the CronJob. Value is the CronJob configuration. See values for more details. |
 
 ### Job Parameters
@@ -75,6 +77,8 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | job.enabled | bool | `false` | Deploy Job resources. |
+| job.securityContext | object, null | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Default Security Context at pod level for all Jobs. Can be overridden per job with `securityContext`. |
+| job.containerSecurityContext | object, null | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Default Security Context at container level for all Jobs. Can be overridden per job with `containerSecurityContext`. |
 | job.jobs | object, null | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details. |
 
 ### Deployment Parameters

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -69,6 +69,12 @@ spec:
           {{- range $key, $value := . }}
           - name: {{ $key }}
             {{- dict "value" (omit $value "name") "context" $ | include "application.tplvalues.render" | nindent 12 }}
+            {{- if not (hasKey $value "securityContext") }}
+            {{- with $job.containerSecurityContext | default $.Values.cronJob.containerSecurityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- end }}
           {{- end }}
           {{- end }}
           containers:
@@ -135,7 +141,7 @@ spec:
             volumeMounts:
 {{ toYaml . | indent 12 }}
             {{- end }}
-            {{- with $job.containerSecurityContext }}
+            {{- with $job.containerSecurityContext | default $.Values.cronJob.containerSecurityContext }}
             securityContext:
               {{- toYaml . | nindent 14 }}
             {{- end }}
@@ -165,7 +171,7 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with $job.securityContext }}
+          {{- with $job.securityContext | default $.Values.cronJob.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -138,6 +138,10 @@ spec:
         - containerPort: 8443
         {{- end }}
           name: proxy
+        {{- with .Values.deployment.openshiftOAuthProxy.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /etc/tls/private
           name: proxy-tls

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -86,6 +86,12 @@ spec:
   {{- range $key, $value := .Values.deployment.initContainers }}
       - name: {{ $key }}
 {{ include "application.tplvalues.render" ( dict "value" $value "context" $ ) | indent 8 }}
+        {{- if not (hasKey $value "securityContext") }}
+        {{- with $.Values.deployment.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
       {{- end }}
       {{- end }}
       {{- if .Values.deployment.nodeSelector }}
@@ -301,10 +307,18 @@ spec:
         {{- $containers := . }}
         {{- range $name := keys . | sortAlpha }}
         {{- $container := index $containers $name }}
+        {{- if and (not (hasKey $container "securityContext")) $.Values.deployment.containerSecurityContext }}
+        {{- $container = merge (dict "securityContext" $.Values.deployment.containerSecurityContext) $container }}
+        {{- end }}
       - {{- merge (dict "name" $name) $container | toYaml | nindent 8 }}
         {{- end }}
         {{- else }}
-{{ toYaml . | indent 6 }}
+        {{- range $container := . }}
+        {{- if and (not (hasKey $container "securityContext")) $.Values.deployment.containerSecurityContext }}
+        {{- $container = merge (dict "securityContext" $.Values.deployment.containerSecurityContext) $container }}
+        {{- end }}
+      - {{- $container | toYaml | nindent 8 }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.deployment.securityContext }}

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -49,6 +49,12 @@ spec:
       {{- range $key, $value := . }}
       - name: {{ $key }}
         {{- dict "value" (omit $value "name") "context" $ | include "application.tplvalues.render" | nindent 8 }}
+        {{- if not (hasKey $value "securityContext") }}
+        {{- with $job.containerSecurityContext | default $.Values.job.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
       {{- end }}
       {{- end }}
       containers:
@@ -111,7 +117,7 @@ spec:
         resources:
 {{ toYaml . | indent 10 }}
         {{- end }}
-        {{- with $job.containerSecurityContext }}
+        {{- with $job.containerSecurityContext | default $.Values.job.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -133,7 +139,7 @@ spec:
       {{- with $job.topologySpreadConstraints }}
       topologySpreadConstraints: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $job.securityContext }}
+      {{- with $job.securityContext | default $.Values.job.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/application/tests/__snapshot__/common_test.yaml.snap
+++ b/application/tests/__snapshot__/common_test.yaml.snap
@@ -399,6 +399,13 @@ should match snapshot:
               ports:
                 - containerPort: 8443
                   name: proxy
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
               volumeMounts:
                 - mountPath: /etc/tls/private
                   name: proxy-tls

--- a/application/tests/cronjob_test.yaml
+++ b/application/tests/cronjob_test.yaml
@@ -213,11 +213,13 @@ tests:
           content:
             name: example1
             image: another-example-registry/another-example-image:another-example-tag
+          any: true
       - contains:
           path: spec.jobTemplate.spec.template.spec.initContainers
           content:
             name: example2
             image: another-example-registry/another-example-image:another-example-tag
+          any: true
       - notContains:
           path: spec.jobTemplate.spec.template.spec.initContainers
           content:
@@ -398,7 +400,44 @@ tests:
           path: spec.jobTemplate.spec.template.spec.serviceAccountName
           value: example-app
 
-  - it: does not include container security context by default
+  - it: applies the default security context to init containers unless overridden
+    set:
+      cronJob:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+            initContainers:
+              plain:
+                image: busybox
+              custom:
+                image: busybox
+                securityContext:
+                  runAsNonRoot: false
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers
+          content:
+            name: plain
+            image: busybox
+            securityContext:
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers
+          content:
+            name: custom
+            image: busybox
+            securityContext:
+              runAsNonRoot: false
+
+  - it: applies a restricted container security context by default
     set:
       cronJob:
         enabled: true
@@ -408,8 +447,15 @@ tests:
               repository: example-registry/example-image
               tag: example-tag
     asserts:
-      - notExists:
+      - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
   - it: enable container security context when configured
     set:
@@ -465,7 +511,7 @@ tests:
           path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
           value: true
 
-  - it: does not include pod security context by default
+  - it: applies the runtime default seccomp profile at pod level by default
     set:
       cronJob:
         enabled: true
@@ -475,8 +521,11 @@ tests:
               repository: example-registry/example-image
               tag: example-tag
     asserts:
-      - notExists:
+      - equal:
           path: spec.jobTemplate.spec.template.spec.securityContext
+          value:
+            seccompProfile:
+              type: RuntimeDefault
 
   - it: enable pod security context when configured
     set:

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -20,6 +20,66 @@ tests:
               drop:
                 - ALL
 
+  - it: applies the default security context to init containers unless overridden
+    set:
+      deployment.initContainers:
+        plain:
+          image: busybox
+        custom:
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: plain
+            image: busybox
+            securityContext:
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: custom
+            image: busybox
+            securityContext:
+              runAsNonRoot: false
+
+  - it: applies the default security context to additional containers unless overridden
+    set:
+      deployment.additionalContainers:
+        plain:
+          image: busybox
+        custom:
+          image: busybox
+          securityContext:
+            runAsNonRoot: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: plain
+            image: busybox
+            securityContext:
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: custom
+            image: busybox
+            securityContext:
+              runAsNonRoot: false
+
   - it: applies the runtime default seccomp profile at pod level by default
     asserts:
       - equal:

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -20,6 +20,31 @@ tests:
               drop:
                 - ALL
 
+  - it: applies the runtime default seccomp profile at pod level by default
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            seccompProfile:
+              type: RuntimeDefault
+
+  - it: applies a restricted security context to the OAuth proxy container
+    set:
+      deployment.openshiftOAuthProxy.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: oauth-proxy
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+
   - it: does not include OAuth proxy container if disabled
     set:
       deployment.openshiftOAuthProxy.enabled: false

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -8,6 +8,18 @@ set:
   deployment.image.tag: example-tag
 
 tests:
+  - it: applies a restricted container security context by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+
   - it: does not include OAuth proxy container if disabled
     set:
       deployment.openshiftOAuthProxy.enabled: false

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -213,11 +213,13 @@ tests:
           content:
             name: example1
             image: another-example-registry/another-example-image:another-example-tag
+          any: true
       - contains:
           path: spec.template.spec.initContainers
           content:
             name: example2
             image: another-example-registry/another-example-image:another-example-tag
+          any: true
       - notContains:
           path: spec.template.spec.initContainers
           content:
@@ -394,7 +396,44 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: example-app
 
-  - it: does not include container security context by default
+  - it: applies the default security context to init containers unless overridden
+    set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+            initContainers:
+              plain:
+                image: busybox
+              custom:
+                image: busybox
+                securityContext:
+                  runAsNonRoot: false
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: plain
+            image: busybox
+            securityContext:
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: custom
+            image: busybox
+            securityContext:
+              runAsNonRoot: false
+
+  - it: applies a restricted container security context by default
     set:
       job:
         enabled: true
@@ -404,8 +443,15 @@ tests:
               repository: example-registry/example-image
               tag: example-tag
     asserts:
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
   - it: enable container security context when configured
     set:
@@ -461,7 +507,7 @@ tests:
           path: spec.template.spec.automountServiceAccountToken
           value: true
 
-  - it: does not include pod security context by default
+  - it: applies the runtime default seccomp profile at pod level by default
     set:
       job:
         enabled: true
@@ -471,8 +517,11 @@ tests:
               repository: example-registry/example-image
               tag: example-tag
     asserts:
-      - notExists:
+      - equal:
           path: spec.template.spec.securityContext
+          value:
+            seccompProfile:
+              type: RuntimeDefault
 
   - it: enable pod security context when configured
     set:

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -838,6 +838,30 @@
         "containerSecurityContext": {
           "description": "Security Context at Container Level.",
           "properties": {
+            "allowPrivilegeEscalation": {
+              "default": false,
+              "title": "allowPrivilegeEscalation",
+              "type": "boolean"
+            },
+            "capabilities": {
+              "properties": {
+                "drop": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "drop",
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "title": "capabilities",
+              "type": "object"
+            },
             "readOnlyRootFilesystem": {
               "default": true,
               "title": "readOnlyRootFilesystem",

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1105,6 +1105,51 @@
         },
         "openshiftOAuthProxy": {
           "properties": {
+            "containerSecurityContext": {
+              "description": "Security Context for the OAuth Proxy container.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "default": false,
+                  "title": "allowPrivilegeEscalation",
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "properties": {
+                    "drop": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "drop",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "capabilities",
+                  "type": "object"
+                },
+                "readOnlyRootFilesystem": {
+                  "default": true,
+                  "title": "readOnlyRootFilesystem",
+                  "type": "boolean"
+                },
+                "runAsNonRoot": {
+                  "default": true,
+                  "title": "runAsNonRoot",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "containerSecurityContext",
+              "type": [
+                "object",
+                "null"
+              ]
+            },
             "disableTLSArg": {
               "default": false,
               "description": "If disabled `--http-address=:8081` will be used instead of `--https-address=:8443`. It can be useful when an ingress is enabled for the application.",
@@ -1275,8 +1320,21 @@
           ]
         },
         "securityContext": {
-          "default": "",
           "description": "Security Context for the pod.",
+          "properties": {
+            "seccompProfile": {
+              "properties": {
+                "type": {
+                  "default": "RuntimeDefault",
+                  "title": "type",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "seccompProfile",
+              "type": "object"
+            }
+          },
           "required": [],
           "title": "securityContext",
           "type": [

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -740,6 +740,51 @@
     "cronJob": {
       "description": " example.com/team: team-name example.com/owner: owner-name",
       "properties": {
+        "containerSecurityContext": {
+          "description": "Default Security Context at container level for all CronJobs. Can be overridden per job with `containerSecurityContext`.",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "default": false,
+              "title": "allowPrivilegeEscalation",
+              "type": "boolean"
+            },
+            "capabilities": {
+              "properties": {
+                "drop": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "drop",
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "title": "capabilities",
+              "type": "object"
+            },
+            "readOnlyRootFilesystem": {
+              "default": true,
+              "title": "readOnlyRootFilesystem",
+              "type": "boolean"
+            },
+            "runAsNonRoot": {
+              "default": true,
+              "title": "runAsNonRoot",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "containerSecurityContext",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "enabled": {
           "default": false,
           "description": "Deploy CronJob resources.",
@@ -751,6 +796,29 @@
           "description": "Map of CronJob resources. Key will be used as a name suffix for the CronJob. Value is the CronJob configuration. See values for more details.",
           "required": [],
           "title": "jobs",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "securityContext": {
+          "description": "Default Security Context at pod level for all CronJobs. Can be overridden per job with `securityContext`.",
+          "properties": {
+            "seccompProfile": {
+              "properties": {
+                "type": {
+                  "default": "RuntimeDefault",
+                  "title": "type",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "seccompProfile",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "securityContext",
           "type": [
             "object",
             "null"
@@ -1977,6 +2045,51 @@
     },
     "job": {
       "properties": {
+        "containerSecurityContext": {
+          "description": "Default Security Context at container level for all Jobs. Can be overridden per job with `containerSecurityContext`.",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "default": false,
+              "title": "allowPrivilegeEscalation",
+              "type": "boolean"
+            },
+            "capabilities": {
+              "properties": {
+                "drop": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "drop",
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "title": "capabilities",
+              "type": "object"
+            },
+            "readOnlyRootFilesystem": {
+              "default": true,
+              "title": "readOnlyRootFilesystem",
+              "type": "boolean"
+            },
+            "runAsNonRoot": {
+              "default": true,
+              "title": "runAsNonRoot",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "containerSecurityContext",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "enabled": {
           "default": false,
           "description": "Deploy Job resources.",
@@ -1988,6 +2101,29 @@
           "description": "Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details.",
           "required": [],
           "title": "jobs",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "securityContext": {
+          "description": "Default Security Context at pod level for all Jobs. Can be overridden per job with `securityContext`.",
+          "properties": {
+            "seccompProfile": {
+              "properties": {
+                "type": {
+                  "default": "RuntimeDefault",
+                  "title": "type",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "seccompProfile",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "securityContext",
           "type": [
             "object",
             "null"

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -463,6 +463,10 @@ deployment:
   containerSecurityContext:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   openshiftOAuthProxy:
     # -- (bool) Enable [OpenShift OAuth Proxy](https://github.com/openshift/oauth-proxy).
     # @section -- Deployment Parameters

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -474,6 +474,15 @@ deployment:
     # -- (int) Port on which application is running inside container.
     # @section -- Deployment Parameters
     port: 8080
+    # -- (object, null) Security Context for the OAuth Proxy container.
+    # @section -- Deployment Parameters
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     # -- (string) Secret name for the OAuth Proxy TLS certificate.
     # @section -- Deployment Parameters
     secretName: "openshift-oauth-proxy-tls"
@@ -487,6 +496,8 @@ deployment:
   # -- (object, null) Security Context for the pod.
   # @section -- Deployment Parameters
   securityContext:
+    seccompProfile:
+      type: RuntimeDefault
     # fsGroup: 2000
   # -- (list) Command for the app container.
   # @section -- Deployment Parameters

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -31,6 +31,20 @@ cronJob:
   # -- (bool) Deploy CronJob resources.
   # @section -- CronJob Parameters
   enabled: false
+  # -- (object, null) Default Security Context at pod level for all CronJobs. Can be overridden per job with `securityContext`.
+  # @section -- CronJob Parameters
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  # -- (object, null) Default Security Context at container level for all CronJobs. Can be overridden per job with `containerSecurityContext`.
+  # @section -- CronJob Parameters
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   # -- (object, null) Map of CronJob resources.
   # Key will be used as a name suffix for the CronJob. Value is the CronJob configuration.
   # See values for more details.
@@ -95,6 +109,20 @@ job:
   # -- (bool) Deploy Job resources.
   # @section -- Job Parameters
   enabled: false
+  # -- (object, null) Default Security Context at pod level for all Jobs. Can be overridden per job with `securityContext`.
+  # @section -- Job Parameters
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  # -- (object, null) Default Security Context at container level for all Jobs. Can be overridden per job with `containerSecurityContext`.
+  # @section -- Job Parameters
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   # -- (object, null) Map of Job resources.
   # Key will be used as a name suffix for the Job. Value is the Job configuration.
   # See values for more details.


### PR DESCRIPTION
## What changed

Hardens the chart's default security posture so every workload the chart renders satisfies the Kubernetes restricted Pod Security Standard out of the box.

The restricted container security context applied by default everywhere:

```yaml
readOnlyRootFilesystem: true
runAsNonRoot: true
allowPrivilegeEscalation: false
capabilities:
  drop:
    - ALL
```

### Deployment

- `deployment.containerSecurityContext` (app container) now also sets `allowPrivilegeEscalation: false` and drops all capabilities.
- `deployment.securityContext` (pod level) defaults to `seccompProfile.type: RuntimeDefault`, inherited by all containers.
- Init containers and `additionalContainers` (map and list forms) inherit `deployment.containerSecurityContext` unless they define their own `securityContext`.
- New `deployment.openshiftOAuthProxy.containerSecurityContext` value applies the restricted context to the OAuth proxy sidecar, which previously rendered without any `securityContext`.

### Jobs and CronJobs

- New chart-level defaults `job.securityContext` / `cronJob.securityContext` (pod level, runtime default seccomp profile) and `job.containerSecurityContext` / `cronJob.containerSecurityContext` (restricted container context) apply to every job.
- Per-job `securityContext` / `containerSecurityContext` values override the chart-level defaults, preserving the existing per-job API.
- Job and CronJob init containers inherit the container defaults unless they define their own `securityContext`.

`values.schema.json` and the README parameter table are regenerated accordingly.

## Why

Closes #34. The chart already defaulted to `runAsNonRoot: true` and `readOnlyRootFilesystem: true` for the app container, but as noted in the issue discussion, permissions should also be dropped by default. Jobs, CronJobs, init containers, additional containers, and the OAuth proxy sidecar previously rendered with no security context at all.

## User-visible effects

- Workloads relying on Linux capabilities, privilege escalation, a writable root filesystem, or a root user must now override the relevant default. An explicit `securityContext` / `containerSecurityContext` fully replaces the corresponding default block, so existing customizations are unaffected.
- Pod-level `securityContext` blocks are now always rendered. User-provided keys merge with the seccomp default per Helm value merging.
- The OAuth proxy sidecar is OpenShift-only; its images carry no `USER`, so `runAsNonRoot: true` relies on the SCC-injected UID, which is standard on OpenShift.

## Validation

- `helm unittest`: 403 tests pass, including new tests covering the restricted defaults and per-container overrides for the deployment (app, init, additional, and OAuth proxy containers), Jobs, and CronJobs.
- `helm lint` passes.