### PR TITLE
fix(deployment): switch oauth proxy default image to quay.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.openshiftOAuthProxy.enabled | bool | `false` | Enable [OpenShift OAuth Proxy](https://github.com/openshift/oauth-proxy). |
 | deployment.openshiftOAuthProxy.port | int | `8080` | Port on which application is running inside container. |
 | deployment.openshiftOAuthProxy.secretName | string | `"openshift-oauth-proxy-tls"` | Secret name for the OAuth Proxy TLS certificate. |
-| deployment.openshiftOAuthProxy.image | string | `"openshift/oauth-proxy:latest"` | Image for the OAuth Proxy. |
+| deployment.openshiftOAuthProxy.image | string | `"quay.io/openshift/origin-oauth-proxy:latest"` | Image for the OAuth Proxy. |
 | deployment.openshiftOAuthProxy.disableTLSArg | bool | `false` | If disabled `--http-address=:8081` will be used instead of `--https-address=:8443`. It can be useful when an ingress is enabled for the application. |
 | deployment.securityContext | object, null | `nil` | Security Context for the pod. |
 | deployment.command | list | `[]` | Command for the app container. |

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --cookie-secret=SECRET
-        image: {{ .Values.deployment.openshiftOAuthProxy.image | default "quay.io/openshift/origin-oauth-proxy:latest" }}
+        image: {{ .Values.deployment.openshiftOAuthProxy.image }}
         imagePullPolicy: IfNotPresent
         name: oauth-proxy
         ports:

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --cookie-secret=SECRET
-        image: {{ .Values.deployment.openshiftOAuthProxy.image | default "openshift/oauth-proxy:latest" }}
+        image: {{ .Values.deployment.openshiftOAuthProxy.image | default "quay.io/openshift/origin-oauth-proxy:latest" }}
         imagePullPolicy: IfNotPresent
         name: oauth-proxy
         ports:

--- a/application/tests/__snapshot__/common_test.yaml.snap
+++ b/application/tests/__snapshot__/common_test.yaml.snap
@@ -393,7 +393,7 @@ should match snapshot:
                 - --tls-cert=/etc/tls/private/tls.crt
                 - --tls-key=/etc/tls/private/tls.key
                 - --cookie-secret=SECRET
-              image: openshift/oauth-proxy:latest
+              image: quay.io/openshift/origin-oauth-proxy:latest
               imagePullPolicy: IfNotPresent
               name: oauth-proxy
               ports:

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
       - notContains:
           path: spec.template.spec.containers
           content:
-            image: openshift/oauth-proxy:latest
+            image: quay.io/openshift/origin-oauth-proxy:latest
           any: true
 
   - it: includes OAuth proxy container when enabled
@@ -25,7 +25,7 @@ tests:
       - contains:
           path: spec.template.spec.containers
           content:
-            image: openshift/oauth-proxy:latest
+            image: quay.io/openshift/origin-oauth-proxy:latest
           any: true
 
   - it: does not fail to render when image tag and digest are not given

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1094,7 +1094,7 @@
               "type": "boolean"
             },
             "image": {
-              "default": "openshift/oauth-proxy:latest",
+              "default": "quay.io/openshift/origin-oauth-proxy:latest",
               "description": "Image for the OAuth Proxy.",
               "title": "image",
               "type": "string"

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -475,7 +475,7 @@ deployment:
     secretName: "openshift-oauth-proxy-tls"
     # -- (string) Image for the OAuth Proxy.
     # @section -- Deployment Parameters
-    image: openshift/oauth-proxy:latest
+    image: quay.io/openshift/origin-oauth-proxy:latest
     # -- (bool) If disabled `--http-address=:8081` will be used instead of `--https-address=:8443`.
     # It can be useful when an ingress is enabled for the application.
     # @section -- Deployment Parameters


### PR DESCRIPTION
## What changed

The default image for the OpenShift OAuth proxy sidecar changes from `openshift/oauth-proxy:latest` (Docker Hub) to `quay.io/openshift/origin-oauth-proxy:latest` (Quay). The values default, schema, README, and tests are updated consistently, and the now-redundant in-template image fallback is removed since the values default always applies.

## Why

The Docker Hub image is abandoned: its `latest` tag was last pushed in June 2019, it is amd64-only, and the registry currently rejects anonymous pulls for the repository, so deployments enabling the proxy without overriding the image fail to pull. `quay.io/openshift/origin-oauth-proxy` is the actively maintained image (multi-arch, still updated).

## User-visible effects

Users who enable `deployment.openshiftOAuthProxy` without setting `image` now pull the maintained Quay image. Users who already override `deployment.openshiftOAuthProxy.image` are unaffected.

## Validation

- `helm unittest`: 396 tests pass (snapshot updated for the new image reference).
- `helm lint` passes.
