### PR TITLE
feat: Support for StatefulSets, DaemonSets and Headless Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deployment.enabled | bool | `true` | Enable Deployment. |
+| deployment.kind | string | `"Deployment"` | Define the kind of workload. Must specify either one of the following field when enabled: Deployment, StatefulSet, DaemonSet |
 | deployment.additionalLabels | object, null | `nil` | Additional labels for Deployment. |
 | deployment.podLabels | object, null | `nil` | Additional pod labels which are used in Service's Label Selector. |
 | deployment.annotations | object, null | `nil` | Annotations for Deployment. |
@@ -182,6 +183,17 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | service.type | string | `"ClusterIP"` | Type of service. |
 | service.clusterIP | string, null | `nil` | Fixed IP for a ClusterIP service. Set to `None` for an headless service |
 | service.loadBalancerClass | string, null | `nil` | LoadBalancer class name for LoadBalancer type services. |
+| headlessService.name | string, null | `nil` | Optional override for service name Defaults to application.name-headless |
+
+### Headless Service Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| headlessService.enabled | bool | `false` | Enable Headless Service for StatefulSet. |
+| headlessService.additionalLabels | object, null | `nil` | Additional labels for headless service. |
+| headlessService.annotations | object, null | `nil` | Annotations for headless service. |
+| headlessService.ports | list | `[{"name":"http","port":8080,"protocol":"TCP","targetPort":8080}]` | Ports for applications service. |
+| headlessService.ports[0].targetPort | int, string, null | `8080` | Target port on pods. Accepts port number or port name (IANA_SVC_NAME). |
 
 ### Ingress Parameters
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.podLabels | object, null | `nil` | Additional pod labels which are used in Service's Label Selector. |
 | deployment.annotations | object, null | `nil` | Annotations for Deployment. |
 | deployment.additionalPodAnnotations | object, null | `nil` | Additional pod annotations. |
-| deployment.strategy.type | string | `"RollingUpdate"` | Type of deployment strategy. |
+| deployment.strategy.type | string | `"RollingUpdate"` | Type of deployment strategy. Only for Deployments. |
+| deployment.updateStrategy.type | string | `"RollingUpdate"` | Type of deployment.updateStrategy. Only works for StatefulSets and DaemonSets |
+| deployment.podManagementPolicy | string | `"OrderedReady"` | Type of deployment.podManagementPolicy. Only works for StatefulSets. One of OrderedReady or Parallel |
 | deployment.reloadOnChange | bool | `true` | Reload deployment if attached Secret/ConfigMap changes. |
 | deployment.nodeSelector | object, null | `nil` | Select the node where the pods should be scheduled. |
 | deployment.hostAliases | list, null | `nil` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files. |
@@ -98,7 +100,9 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.envFrom | object, null | `nil` | Mount environment variables from ConfigMap or Secret to the pod. Use `nameSuffix` for resources managed by this chart (name will be prefixed with application name), or `name` to reference an existing external ConfigMap or Secret not managed by this chart. See the README "Consuming environment variable in application chart" section for more details. |
 | deployment.env | object, null | `nil` | Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details. |
 | deployment.volumes | object, null | `nil` | Volumes to be added to the pod. Key is the name of the volume. Value is the volume definition. |
+| deployment.volumeClaimTemplates | object, null | `nil` | VolumeClaimTemplates to be added to the pods. Key is the name of the volume. Value is the spec for volumeClaimTemplate. Use only for StatefulSets. |
 | deployment.volumeMounts | object, null | `nil` | Mount path for Volumes. Key is the name of the volume. Value is the volume mount definition. |
+| deployment.persistentVolumeClaimRetentionPolicy | object, null | `nil` | Rules on what to do with residual PVCs for StatefulSets. No-op for Deployments or DaemonSets. |
 | deployment.priorityClassName | string, null | `""` | Define the priority class for the pod. |
 | deployment.runtimeClassName | string, null | `""` | Set the runtimeClassName for the deployment's pods. |
 | deployment.tolerations | list, null | `nil` | Taint tolerations for the pods. |

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | headlessService.annotations | object, null | `nil` | Annotations for headless service. |
 | headlessService.ports | list | `[{"name":"http","port":8080,"protocol":"TCP","targetPort":8080}]` | Ports for applications service. |
 | headlessService.ports[0].targetPort | int, string, null | `8080` | Target port on pods. Accepts port number or port name (IANA_SVC_NAME). |
-| headlessService.publishNotReadyAddresses | bool | `nil` | Propagate SRV DNS records for Pods to enable peer discovery, by disregarding any indications of ready/not-ready for Pods. |
+| headlessService.publishNotReadyAddresses | bool, null | `nil` | Propagate SRV DNS records for Pods to enable peer discovery, by disregarding any indications of ready/not-ready for Pods. |
 
 ### Ingress Parameters
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Application
 
-Generic Helm chart for deploying stateless applications on Kubernetes. Supports Deployments, Jobs, and CronJobs along with common companion resources (Services, Ingress, RBAC, autoscaling, monitoring, certificates, and more).
+Generic Helm chart for deploying applications on Kubernetes. Supports Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs along with common companion resources (Services, Ingress, RBAC, autoscaling, monitoring, certificates, and more).
 
 ## Installing the Chart
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | headlessService.annotations | object, null | `nil` | Annotations for headless service. |
 | headlessService.ports | list | `[{"name":"http","port":8080,"protocol":"TCP","targetPort":8080}]` | Ports for applications service. |
 | headlessService.ports[0].targetPort | int, string, null | `8080` | Target port on pods. Accepts port number or port name (IANA_SVC_NAME). |
+| headlessService.publishNotReadyAddresses | bool | `nil` | Propagate SRV DNS records for Pods to enable peer discovery, by disregarding any indications of ready/not-ready for Pods. |
 
 ### Ingress Parameters
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -2,7 +2,7 @@
 
 # Application
 
-Generic Helm chart for deploying stateless applications on Kubernetes. Supports Deployments, Jobs, and CronJobs along with common companion resources (Services, Ingress, RBAC, autoscaling, monitoring, certificates, and more).
+Generic Helm chart for deploying applications on Kubernetes. Supports Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs along with common companion resources (Services, Ingress, RBAC, autoscaling, monitoring, certificates, and more).
 
 ## Installing the Chart
 

--- a/application/Chart.yaml
+++ b/application/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: application
-description: Generic Helm chart for deploying stateless applications on Kubernetes
+description: Generic Helm chart for deploying applications on Kubernetes
 type: application
 version: 9.3.1
 keywords:

--- a/application/ci/values.yaml
+++ b/application/ci/values.yaml
@@ -6,12 +6,13 @@ additionalLabels:
   team: stakater
 
 deployment:
+  kind: StatefulSet
   dnsConfig:
     options:
       - name: ndots
         value: "1"
   dnsPolicy: ClusterFirst
-  strategy:
+  updateStrategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 25%
@@ -99,6 +100,17 @@ deployment:
   volumeMounts:
     volume-name:
       mountPath: /path1
+    volume-claim-template-name:
+      mountPath: /path2
+  volumeClaimTemplates:
+    volume-claim-template-name:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
   tolerations:
     - key: dedicated
       operator: Equal

--- a/application/ci/values.yaml
+++ b/application/ci/values.yaml
@@ -15,7 +15,7 @@ deployment:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 25%
+      # maxSurge: 25%
       maxUnavailable: 25%
   reloadOnChange: true
   hostAliases:

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.deployment.enabled }}
+{{- $kindsWithHeadlessService := list "StatefulSet" -}}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.deployment.kind  | default "Deployment" }}
 metadata:
   labels:
   {{- include "application.labels" $ | nindent 4 }}
@@ -20,6 +21,9 @@ metadata:
   name: {{ template "application.name" . }}
   namespace: {{ include "application.namespace" . }}
 spec:
+{{- if and (has .Values.deployment.kind $kindsWithHeadlessService) ((.Values.headlessService).enabled) }}
+  serviceName: {{ .Values.headlessService.name | default (printf "%s-headless" (include "application.name" .)) }}
+{{- end }}
 {{- if not (eq .Values.deployment.replicas nil) }}
   replicas: {{ .Values.deployment.replicas }}
 {{- end }}

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -1,5 +1,10 @@
 {{- if .Values.deployment.enabled }}
 {{- $kindsWithHeadlessService := list "StatefulSet" -}}
+{{- $kindsWithPodManagementPolicy := list "StatefulSet" -}}
+{{- $kindsWithReplicas := list "Deployment" "StatefulSet" -}}
+{{- $kindsWithStrategy := list "Deployment" -}}
+{{- $kindsWithUpdateStrategy := list "DaemonSet" "StatefulSet" -}}
+{{- $kindsWithVolumeClaimTemplates := list "StatefulSet" -}}
 ---
 apiVersion: apps/v1
 kind: {{ .Values.deployment.kind  | default "Deployment" }}
@@ -24,13 +29,23 @@ spec:
 {{- if and (has .Values.deployment.kind $kindsWithHeadlessService) ((.Values.headlessService).enabled) }}
   serviceName: {{ .Values.headlessService.name | default (printf "%s-headless" (include "application.name" .)) }}
 {{- end }}
+{{- if has .Values.deployment.kind $kindsWithReplicas }}
 {{- if not (eq .Values.deployment.replicas nil) }}
   replicas: {{ .Values.deployment.replicas }}
+{{- end }}
 {{- end }}
   selector:
     matchLabels:
 {{ include "application.selectorLabels" . | indent 6 }}
-  {{- if .Values.deployment.strategy }}
+  {{- if has .Values.deployment.kind $kindsWithPodManagementPolicy }}
+  {{- with .Values.deployment.podManagementPolicy }}
+  podManagementPolicy: {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if and (has .Values.deployment.kind $kindsWithUpdateStrategy) .Values.deployment.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.deployment.updateStrategy | indent 4 }}
+  {{- else if and (has .Values.deployment.kind $kindsWithStrategy) .Values.deployment.strategy }}
   strategy:
 {{ toYaml .Values.deployment.strategy | indent 4 }}
   {{- end }}
@@ -348,4 +363,17 @@ spec:
       {{- if not (kindIs "invalid" .Values.deployment.minReadySeconds) }}
       minReadySeconds: {{ .Values.deployment.minReadySeconds }}
       {{- end }}
+  {{- if and (has .Values.deployment.kind $kindsWithVolumeClaimTemplates) .Values.deployment.volumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- range $key, $value := .Values.deployment.volumeClaimTemplates }}
+  - metadata:
+      name: {{ $key }}
+    spec:
+{{ include "application.tplvalues.render" ( dict "value" $value "context" $ ) | indent 6 }}
+    {{- end }}
+    {{- if .Values.deployment.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+{{ toYaml .Values.deployment.persistentVolumeClaimRetentionPolicy | indent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/application/templates/headlessservice.yaml
+++ b/application/templates/headlessservice.yaml
@@ -17,7 +17,9 @@ metadata:
 spec:
   clusterIP: None
   type: ClusterIP
+  {{- if .Values.headlessService.publishNotReadyAddresses }}
   publishNotReadyAddresses: {{ .Values.headlessService.publishNotReadyAddresses | default false }}
+  {{- end }}
   selector:
 {{ include "application.selectorLabels" . | indent 4 }}
   ports:

--- a/application/templates/headlessservice.yaml
+++ b/application/templates/headlessservice.yaml
@@ -1,0 +1,24 @@
+{{- if (.Values.headlessService).enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.headlessService.name | default (printf "%s-headless" (include "application.name" .)) }}
+  namespace: {{ template "application.namespace" $ }}
+  labels:
+  {{- include "application.labels" $ | nindent 4 }}
+  {{- if .Values.headlessService.additionalLabels }}
+    {{- toYaml .Values.headlessService.additionalLabels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.headlessService.annotations }}
+  annotations:
+    {{- include "application.tplvalues.render" ( dict "value" .Values.headlessService.annotations  "context" $ ) | nindent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector:
+{{ include "application.selectorLabels" . | indent 4 }}
+  ports:
+{{ toYaml .Values.headlessService.ports | indent 4 }}
+{{- end }}

--- a/application/templates/headlessservice.yaml
+++ b/application/templates/headlessservice.yaml
@@ -17,6 +17,7 @@ metadata:
 spec:
   clusterIP: None
   type: ClusterIP
+  publishNotReadyAddresses: {{ .Values.headlessService.publishNotReadyAddresses | default false }}
   selector:
 {{ include "application.selectorLabels" . | indent 4 }}
   ports:

--- a/application/templates/hpa.yaml
+++ b/application/templates/hpa.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.deployment.kind }}
     name: {{ template "application.name" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/application/templates/vpa.yaml
+++ b/application/templates/vpa.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   targetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.deployment.kind }}
     name: {{ template "application.name" . }}
   resourcePolicy:
     containerPolicies:

--- a/application/tests/__snapshot__/common_test.yaml.snap
+++ b/application/tests/__snapshot__/common_test.yaml.snap
@@ -592,7 +592,6 @@ should match snapshot:
               name: volume-name
       updateStrategy:
         rollingUpdate:
-          maxSurge: 25%
           maxUnavailable: 25%
         type: RollingUpdate
       volumeClaimTemplates:

--- a/application/tests/__snapshot__/common_test.yaml.snap
+++ b/application/tests/__snapshot__/common_test.yaml.snap
@@ -318,7 +318,7 @@ should match snapshot:
       schedule: '* * * 8 *'
   11: |
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     metadata:
       annotations:
         reloader.stakater.com/auto: "true"
@@ -334,17 +334,16 @@ should match snapshot:
       name: application
       namespace: NAMESPACE
     spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Delete
+        whenScaled: Retain
+      podManagementPolicy: OrderedReady
       replicas: 2
       revisionHistoryLimit: 2
       selector:
         matchLabels:
           app.kubernetes.io/name: application
           application.stakater.com/workload-class: serving
-      strategy:
-        rollingUpdate:
-          maxSurge: 25%
-          maxUnavailable: 25%
-        type: RollingUpdate
       template:
         metadata:
           annotations:
@@ -486,6 +485,8 @@ should match snapshot:
                 successThreshold: 1
                 timeoutSeconds: 1
               volumeMounts:
+                - mountPath: /path2
+                  name: volume-claim-template-name
                 - mountPath: /path1
                   name: volume-name
             - command:
@@ -589,6 +590,20 @@ should match snapshot:
                 secretName: secret-name
             - emptyDir: {}
               name: volume-name
+      updateStrategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      volumeClaimTemplates:
+        - metadata:
+            name: volume-claim-template-name
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
   12: |
     apiVersion: endpointmonitor.stakater.com/v1alpha1
     kind: EndpointMonitor
@@ -1302,7 +1317,7 @@ should match snapshot:
       minReplicas: 1
       scaleTargetRef:
         apiVersion: apps/v1
-        kind: Deployment
+        kind: StatefulSet
         name: application
   21: |
     apiVersion: networking.k8s.io/v1
@@ -1855,7 +1870,7 @@ should match snapshot:
               memory: 1Gi
       targetRef:
         apiVersion: apps/v1
-        kind: Deployment
+        kind: StatefulSet
         name: application
       updatePolicy:
         updateMode: Auto

--- a/application/tests/common_test.yaml
+++ b/application/tests/common_test.yaml
@@ -10,6 +10,7 @@ values:
 capabilities:
   apiVersions:
     # TODO: auto add all/used apiVersions
+    - apps/v1
     - batch/v1
     - batch/v1/CronJob
     - policy/v1

--- a/application/tests/deployment_test.yaml
+++ b/application/tests/deployment_test.yaml
@@ -391,3 +391,17 @@ tests:
           content:
             name: sidecar
           any: true
+
+  - it: workload type defaults to Deployment if not set
+    asserts:
+      - equal:
+          path: kind
+          value: Deployment
+
+  - it: sets correct workload type if given
+    set:
+      deployment.kind: StatefulSet
+    asserts:
+      - equal:
+          path: kind
+          value: StatefulSet

--- a/application/tests/headlessservice_test.yaml
+++ b/application/tests/headlessservice_test.yaml
@@ -1,0 +1,162 @@
+suite: Headless Service
+templates:
+  - headlessservice.yaml
+
+tests:
+  - it: includes correct metadata name
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+      applicationName: my-app
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-app-headless
+
+  - it: includes correct namespace
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+      applicationName: my-app
+    release:
+      namespace: test-namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+
+  - it: includes additional labels when defined
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+        additionalLabels:
+          foo: bar
+          test: ing
+    asserts:
+      - equal:
+          path: metadata.labels.foo
+          value: bar
+      - equal:
+          path: metadata.labels.test
+          value: ing
+
+  - it: includes annotations when defined
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+        annotations:
+          custom: annotation
+    asserts:
+      - equal:
+          path: metadata.annotations.custom
+          value: annotation
+
+  - it: does not include annotations if none are defined
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+        annotations: {}
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: clusterIP is always None regardless of input
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+        clusterIP: 10.0.0.1
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: None
+
+  - it: service type is always ClusterIP regardless of input
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+        type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: metadata name can be overridden
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+        name: my-svc
+      applicationName: my-app
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-svc
+
+  - it: includes ports when defined
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+        ports:
+          - name: http
+            port: 80
+            targetPort: 8080
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8080
+
+  - it: uses app.kubernetes.io/name and application.stakater.com/workload-class as selector labels
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+      applicationName: my-app
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: my-app
+      - equal:
+          path: spec.selector["application.stakater.com/workload-class"]
+          value: serving
+
+  - it: service selector specifically requires workload-class serving to exclude batch and scheduled workloads
+    set:
+      workload:
+        kind: StatefulSet
+      headlessService:
+        enabled: true
+      applicationName: my-app
+    asserts:
+      - equal:
+          path: spec.selector["application.stakater.com/workload-class"]
+          value: serving
+      - notEqual:
+          path: spec.selector["application.stakater.com/workload-class"]
+          value: batch
+      - notEqual:
+          path: spec.selector["application.stakater.com/workload-class"]
+          value: scheduled

--- a/application/tests/hpa_test.yaml
+++ b/application/tests/hpa_test.yaml
@@ -80,3 +80,16 @@ tests:
     asserts:
       - isAPIVersion:
           of: autoscaling/v2beta2
+
+  - it: scales proper target
+    set:
+      deployment:
+        enabled: true
+        kind: StatefulSet
+      autoscaling:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: StatefulSet
+

--- a/application/tests/vpa_test.yaml
+++ b/application/tests/vpa_test.yaml
@@ -26,6 +26,9 @@ tests:
   - it: renders a basic VerticalPodAutoscaler with minimal configuration
     set:
       applicationName: example
+      deployment:
+        enabled: true
+        kind: Deployment
       vpa:
         enabled: true
         containerPolicies:

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -987,6 +987,12 @@
             "null"
           ]
         },
+        "kind": {
+          "default": "Deployment",
+          "description": "Define the kind of workload. Must specify either one of the following field when enabled: Deployment, StatefulSet, DaemonSet",
+          "title": "kind",
+          "type": "string"
+        },
         "lifecycle": {
           "description": "Lifecycle configuration for the pod.",
           "required": [],
@@ -1622,6 +1628,91 @@
       },
       "required": [],
       "title": "grafanaDashboard",
+      "type": "object"
+    },
+    "headlessService": {
+      "properties": {
+        "additionalLabels": {
+          "default": "",
+          "description": "Additional labels for headless service.",
+          "required": [],
+          "title": "additionalLabels",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "annotations": {
+          "default": "",
+          "description": "Annotations for headless service.",
+          "required": [],
+          "title": "annotations",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable Headless Service for StatefulSet.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "name": {
+          "default": "",
+          "description": "Optional override for service name Defaults to application.name-headless",
+          "required": [],
+          "title": "name",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ports": {
+          "description": "Ports for applications service.",
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "name": {
+                    "default": "http",
+                    "title": "name",
+                    "type": "string"
+                  },
+                  "port": {
+                    "default": 8080,
+                    "title": "port",
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "default": "TCP",
+                    "title": "protocol",
+                    "type": "string"
+                  },
+                  "targetPort": {
+                    "default": 8080,
+                    "description": "Target port on pods. Accepts port number or port name (IANA_SVC_NAME).",
+                    "required": [],
+                    "title": "targetPort",
+                    "type": [
+                      "integer",
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [],
+                "type": "object"
+              }
+            ],
+            "required": []
+          },
+          "title": "ports",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "headlessService",
       "type": "object"
     },
     "httpRoute": {

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1752,8 +1752,12 @@
         "publishNotReadyAddresses": {
           "default": "",
           "description": "Propagate SRV DNS records for Pods to enable peer discovery, by disregarding any indications of ready/not-ready for Pods.",
+          "required": [],
           "title": "publishNotReadyAddresses",
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "required": [],

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1748,6 +1748,12 @@
           },
           "title": "ports",
           "type": "array"
+        },
+        "publishNotReadyAddresses": {
+          "default": "",
+          "description": "Propagate SRV DNS records for Pods to enable peer discovery, by disregarding any indications of ready/not-ready for Pods.",
+          "title": "publishNotReadyAddresses",
+          "type": "boolean"
         }
       },
       "required": [],

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1122,6 +1122,16 @@
           "title": "openshiftOAuthProxy",
           "type": "object"
         },
+        "persistentVolumeClaimRetentionPolicy": {
+          "default": "",
+          "description": "Rules on what to do with residual PVCs for StatefulSets. No-op for Deployments or DaemonSets.",
+          "required": [],
+          "title": "persistentVolumeClaimRetentionPolicy",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "podLabels": {
           "default": "",
           "description": "Additional pod labels which are used in Service's Label Selector.",
@@ -1131,6 +1141,12 @@
             "object",
             "null"
           ]
+        },
+        "podManagementPolicy": {
+          "default": "OrderedReady",
+          "description": "Type of deployment.podManagementPolicy. Only works for StatefulSets. One of OrderedReady or Parallel",
+          "title": "podManagementPolicy",
+          "type": "string"
         },
         "ports": {
           "default": "",
@@ -1336,7 +1352,7 @@
           "properties": {
             "type": {
               "default": "RollingUpdate",
-              "description": "Type of deployment strategy.",
+              "description": "Type of deployment strategy. Only for Deployments.",
               "title": "type",
               "type": "string"
             }
@@ -1372,6 +1388,29 @@
           "title": "topologySpreadConstraints",
           "type": [
             "array",
+            "null"
+          ]
+        },
+        "updateStrategy": {
+          "properties": {
+            "type": {
+              "default": "RollingUpdate",
+              "description": "Type of deployment.updateStrategy. Only works for StatefulSets and DaemonSets",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "updateStrategy",
+          "type": "object"
+        },
+        "volumeClaimTemplates": {
+          "default": "",
+          "description": "VolumeClaimTemplates to be added to the pods. Key is the name of the volume. Value is the spec for volumeClaimTemplate. Use only for StatefulSets.",
+          "required": [],
+          "title": "volumeClaimTemplates",
+          "type": [
+            "object",
             "null"
           ]
         },

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -667,7 +667,7 @@ headlessService:
       # -- (int, string, null) Target port on pods. Accepts port number or port name (IANA_SVC_NAME).
       # @section -- Headless Service Parameters
       targetPort: 8080
-  # -- (bool) Propagate SRV DNS records for Pods to enable peer discovery, by disregarding any indications of ready/not-ready for Pods.
+  # -- (bool, null) Propagate SRV DNS records for Pods to enable peer discovery, by disregarding any indications of ready/not-ready for Pods.
   # @section -- Headless Service Parameters
   publishNotReadyAddresses:
 

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -667,6 +667,9 @@ headlessService:
       # -- (int, string, null) Target port on pods. Accepts port number or port name (IANA_SVC_NAME).
       # @section -- Headless Service Parameters
       targetPort: 8080
+  # -- (bool) Propagate SRV DNS records for Pods to enable peer discovery, by disregarding any indications of ready/not-ready for Pods.
+  # @section -- Headless Service Parameters
+  publishNotReadyAddresses:
 
 ingress:
   # -- (bool) Enable Ingress.

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -160,6 +160,10 @@ deployment:
   # -- (bool) Enable Deployment.
   # @section -- Deployment Parameters
   enabled: true
+  # -- (string) Define the kind of workload.
+  # Must specify either one of the following field when enabled: Deployment, StatefulSet, DaemonSet
+  # @section -- Deployment Parameters
+  kind: "Deployment"
   # -- (object, null) Additional labels for Deployment.
   # @section -- Deployment Parameters
   additionalLabels:
@@ -610,6 +614,30 @@ service:
   # -- (string, null) LoadBalancer class name for LoadBalancer type services.
   # @section -- Service Parameters
   loadBalancerClass:
+
+headlessService:
+  # -- (bool) Enable Headless Service for StatefulSet.
+  # @section -- Headless Service Parameters
+  enabled: false
+  # -- (string, null) Optional override for service name
+  # Defaults to application.name-headless
+  # @section -- Service Parameters
+  name:
+  # -- (object, null) Additional labels for headless service.
+  # @section -- Headless Service Parameters
+  additionalLabels:
+  # -- (object, null) Annotations for headless service.
+  # @section -- Headless Service Parameters
+  annotations:
+  # -- (list) Ports for applications service.
+  # @section -- Headless Service Parameters
+  ports:
+    - port: 8080
+      name: http
+      protocol: TCP
+      # -- (int, string, null) Target port on pods. Accepts port number or port name (IANA_SVC_NAME).
+      # @section -- Headless Service Parameters
+      targetPort: 8080
 
 ingress:
   # -- (bool) Enable Ingress.

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -178,11 +178,24 @@ deployment:
   additionalPodAnnotations:
   strategy:
     # -- (string) Type of deployment strategy.
+    # Only for Deployments.
     # @section -- Deployment Parameters
     type: RollingUpdate
     # rollingUpdate:
     #   maxUnavailable: 25%
     #   maxSurge: 25%
+  updateStrategy:
+    # -- (string) Type of deployment.updateStrategy.
+    # Only works for StatefulSets and DaemonSets
+    # @section -- Deployment Parameters
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 25%
+    #   maxSurge: 25%
+  # -- (string) Type of deployment.podManagementPolicy.
+  # Only works for StatefulSets. One of OrderedReady or Parallel
+  # @section -- Deployment Parameters
+  podManagementPolicy: OrderedReady
   # -- (bool) Reload deployment if attached Secret/ConfigMap changes.
   # @section -- Deployment Parameters
   reloadOnChange: true
@@ -273,6 +286,16 @@ deployment:
     # persistent-volume-name:
     #   persistentVolumeClaim:
     #     claimName: claim-name
+  # -- (object, null) VolumeClaimTemplates to be added to the pods.
+  # Key is the name of the volume. Value is the spec for volumeClaimTemplate. Use only for StatefulSets.
+  # @section -- Deployment Parameters
+  volumeClaimTemplates:
+    # persistent-volume-name:
+    #   accessModes: [ "ReadWriteOnce" ]
+    #   storageClassName: "my-storage-class"
+    #   resources:
+    #     requests:
+    #       storage: 1Gi
   # -- (object, null) Mount path for Volumes.
   # Key is the name of the volume. Value is the volume mount definition.
   # @section -- Deployment Parameters
@@ -282,6 +305,12 @@ deployment:
     #    subPath: szy
     # volume-name-2:
     #    mountPath: path-2
+  # -- (object, null) Rules on what to do with residual PVCs for StatefulSets.
+  # No-op for Deployments or DaemonSets.
+  # @section -- Deployment Parameters
+  persistentVolumeClaimRetentionPolicy:
+    # whenDeleted: Retain
+    # whenScaled: Retain
   # -- (string, null) Define the priority class for the pod.
   # @section -- Deployment Parameters
   priorityClassName: ""
@@ -1491,6 +1520,8 @@ backup:
   # @section -- Backup Parameters
   includedResources:
     # - deployments
+    # - statefulsets
+    # - daemonsets
     # - services
   # -- (list, null) List of resource types to exclude from the backup.
   # @section -- Backup Parameters
@@ -1501,6 +1532,8 @@ backup:
   # @section -- Backup Parameters
   includedNamespaceScopedResources:
     # - deployments
+    # - statefulsets
+    # - daemonsets
     # - services
   # -- (list, null) List of namespace-scoped resource types to exclude from the backup.
   # @section -- Backup Parameters
@@ -1513,6 +1546,12 @@ backup:
     # deployments:
     #   - my-deployment-1
     #   - my-deployment-2
+    # statefulsets:
+    #   - my-statefulset-1
+    #   - my-statefulset-2
+    # daemonsets:
+    #   - my-daemonset-1
+    #   - my-daemonset-2
 
 # -- (list, object, null) Extra K8s manifests to deploy.
 # Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are evaluated as templates.


### PR DESCRIPTION
### Changes
- enhanced the deployment template to accommodate variations between `Deployment`/`StatefulSet`/`DaemonSet`
- created a new template for headless `Service` to accompany `StatefulSet`
- HPA and VPA now reflects the `deployment.kind`
- added/edited test cases to cover the above changes
- updated docs to increase scope of chart (no longer 'stateless-only')

### Closes
#319 

### Remarks
- The idea of changing the top attribute from `deployment` to `workload` was discarded as it is deemed too intrusive.