### PR TITLE
feat(chart): inherit deployment defaults and persistence volume in Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | job.enabled | bool | `false` | Deploy Job resources. |
-| job.jobs | object, null | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details. |
+| job.jobs | object, null | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. Each Job inherits `image`, `imagePullSecrets`, `automountServiceAccountToken`, `containerSecurityContext` and `securityContext` from `deployment` unless overridden, and mounts the chart-managed PVC when `persistence.enabled` and `persistence.mountPVC` are set. Set `inheritFromDeployment: false` on a Job to opt out of the inherited defaults. See values for more details. |
 
 ### Deployment Parameters
 

--- a/application/ci/values.yaml
+++ b/application/ci/values.yaml
@@ -220,8 +220,8 @@ deployment:
 
 persistence:
   enabled: true
-  mountPVC: false
-  mountPath: /
+  mountPVC: true
+  mountPath: /data
   accessMode: ReadWriteOnce
   storageClass: "-"
   additionalLabels:

--- a/application/templates/job.yaml
+++ b/application/templates/job.yaml
@@ -1,5 +1,29 @@
 {{- if (.Values.job).enabled }}
+{{- $deployment := (.Values.deployment | default dict) }}
+{{- $mountPVC := and ((.Values.persistence).enabled) ((.Values.persistence).mountPVC) }}
+{{- $pvcVolumeName := printf "%s-%s" (include "application.name" $) "data" | trunc 63 | trimSuffix "-" }}
 {{- range $name, $job := .Values.job.jobs }}
+{{- $job = ($job | default dict) }}
+{{- /* Defaults inherited from `.Values.deployment`. Anything set on the job itself always wins. */}}
+{{- if not (eq false $job.inheritFromDeployment) }}
+{{- $inherited := dict }}
+{{- range $key := list "imagePullSecrets" "automountServiceAccountToken" "containerSecurityContext" "securityContext" }}
+{{- if not (kindIs "invalid" (index $deployment $key)) }}
+{{- $_ := set $inherited $key (index $deployment $key) }}
+{{- end }}
+{{- end }}
+{{- /* Image: inherit the full block only when the job defines no repository of its own. */}}
+{{- $deploymentImage := ($deployment.image | default dict) }}
+{{- $jobImage := ($job.image | default dict) }}
+{{- $inheritedImage := dict "imagePullPolicy" $deploymentImage.pullPolicy }}
+{{- if not $jobImage.repository }}
+{{- $_ := set $inheritedImage "repository" $deploymentImage.repository }}
+{{- $_ := set $inheritedImage "tag" $deploymentImage.tag }}
+{{- $_ := set $inheritedImage "digest" $deploymentImage.digest }}
+{{- end }}
+{{- $_ := set $inherited "image" (merge (deepCopy $jobImage) $inheritedImage) }}
+{{- $job = merge (deepCopy $job) $inherited }}
+{{- end }}
 ---
 {{ if $.Capabilities.APIVersions.Has "batch/v1/Job" -}}
 apiVersion: batch/v1
@@ -115,9 +139,15 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with $job.volumeMounts }}
+        {{- if or $job.volumeMounts $mountPVC }}
         volumeMounts:
+        {{- if $mountPVC }}
+        - mountPath: {{ $.Values.persistence.mountPath }}
+          name: {{ $pvcVolumeName }}
+        {{- end }}
+        {{- with $job.volumeMounts }}
 {{ toYaml . | indent 8 }}
+        {{- end }}
         {{- end }}
       {{- with $job.nodeSelector }}
       nodeSelector:
@@ -159,9 +189,16 @@ spec:
       {{- with $job.hostAliases }}
       hostAliases: {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with $job.volumes }}
+      {{- if or $job.volumes $mountPVC }}
       volumes:
+      {{- if $mountPVC }}
+        - name: {{ $pvcVolumeName }}
+          persistentVolumeClaim:
+            claimName: {{ $.Values.persistence.name | default $pvcVolumeName }}
+      {{- end }}
+      {{- with $job.volumes }}
 {{ toYaml . | indent 8 }}
+      {{- end }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/application/tests/__snapshot__/common_test.yaml.snap
+++ b/application/tests/__snapshot__/common_test.yaml.snap
@@ -486,6 +486,8 @@ should match snapshot:
                 successThreshold: 1
                 timeoutSeconds: 1
               volumeMounts:
+                - mountPath: /data
+                  name: application-data
                 - mountPath: /path1
                   name: volume-name
             - command:
@@ -575,6 +577,9 @@ should match snapshot:
             - name: proxy-tls
               secret:
                 secretName: openshift-oauth-proxy-tls
+            - name: application-data
+              persistentVolumeClaim:
+                claimName: application-data
             - configMap:
                 name: configmap-name
               name: config-volume
@@ -1406,6 +1411,7 @@ should match snapshot:
                     name: my-existing-secret
                     optional: false
               image: example-registry/example-image:example-tag@sha256:example-digest
+              imagePullPolicy: IfNotPresent
               name: db-migration
               resources:
                 limits:
@@ -1424,6 +1430,9 @@ should match snapshot:
                 runAsUser: 65534
                 seccompProfile:
                   type: RuntimeDefault
+              volumeMounts:
+                - mountPath: /data
+                  name: application-data
           dnsConfig:
             options:
               - name: ndots
@@ -1437,6 +1446,10 @@ should match snapshot:
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: application
+          volumes:
+            - name: application-data
+              persistentVolumeClaim:
+                claimName: application-data
   23: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy

--- a/application/tests/job_test.yaml
+++ b/application/tests/job_test.yaml
@@ -394,8 +394,26 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: example-app
 
-  - it: does not include container security context by default
+  - it: inherits the container security context from the deployment by default
     set:
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+
+  - it: does not include container security context when the deployment defines none
+    set:
+      deployment:
+        containerSecurityContext: null
       job:
         enabled: true
         jobs:
@@ -406,6 +424,187 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].securityContext
+
+  - it: does not inherit from the deployment when inheritFromDeployment is disabled
+    set:
+      deployment:
+        image:
+          repository: deployment-registry/deployment-image
+          tag: deployment-tag
+        securityContext:
+          fsGroup: 2000
+      job:
+        enabled: true
+        jobs:
+          example:
+            inheritFromDeployment: false
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+      - notExists:
+          path: spec.template.spec.securityContext
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-registry/example-image:example-tag
+
+  - it: inherits image, pull policy, pull secrets and pod security context from the deployment
+    set:
+      deployment:
+        image:
+          repository: deployment-registry/deployment-image
+          tag: deployment-tag
+          pullPolicy: Always
+        imagePullSecrets:
+          - name: docker-pull
+        securityContext:
+          fsGroup: 2000
+      job:
+        enabled: true
+        jobs:
+          example: {}
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: deployment-registry/deployment-image:deployment-tag
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: docker-pull
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            fsGroup: 2000
+
+  - it: prefers the job image over the inherited deployment image
+    set:
+      deployment:
+        image:
+          repository: deployment-registry/deployment-image
+          tag: deployment-tag
+          pullPolicy: Always
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+              imagePullPolicy: IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example-registry/example-image:example-tag
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: mounts the chart managed PVC when persistence is enabled
+    set:
+      applicationName: example-app
+      persistence:
+        enabled: true
+        mountPVC: true
+        mountPath: /data
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - mountPath: /data
+              name: example-app-data
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: example-app-data
+              persistentVolumeClaim:
+                claimName: example-app-data
+
+  - it: uses the configured PVC name when persistence name is set
+    set:
+      applicationName: example-app
+      persistence:
+        enabled: true
+        mountPVC: true
+        mountPath: /data
+        name: existing-claim
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: existing-claim
+
+  - it: keeps job volumes and volumeMounts alongside the persistence mount
+    set:
+      applicationName: example-app
+      persistence:
+        enabled: true
+        mountPVC: true
+        mountPath: /data
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+            volumeMounts:
+              - name: extra
+                mountPath: /tmp/extra
+            volumes:
+              - name: extra
+                emptyDir: {}
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - mountPath: /data
+              name: example-app-data
+            - name: extra
+              mountPath: /tmp/extra
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: example-app-data
+              persistentVolumeClaim:
+                claimName: example-app-data
+            - name: extra
+              emptyDir: {}
+
+  - it: does not mount the PVC when persistence is enabled but mountPVC is disabled
+    set:
+      persistence:
+        enabled: true
+        mountPVC: false
+      job:
+        enabled: true
+        jobs:
+          example:
+            image:
+              repository: example-registry/example-image
+              tag: example-tag
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+      - notExists:
+          path: spec.template.spec.volumes
 
   - it: enable container security context when configured
     set:

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -1903,7 +1903,7 @@
         },
         "jobs": {
           "default": "",
-          "description": "Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details.",
+          "description": "Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. Each Job inherits `image`, `imagePullSecrets`, `automountServiceAccountToken`, `containerSecurityContext` and `securityContext` from `deployment` unless overridden, and mounts the chart-managed PVC when `persistence.enabled` and `persistence.mountPVC` are set. Set `inheritFromDeployment: false` on a Job to opt out of the inherited defaults. See values for more details.",
           "required": [],
           "title": "jobs",
           "type": [

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -97,10 +97,15 @@ job:
   enabled: false
   # -- (object, null) Map of Job resources.
   # Key will be used as a name suffix for the Job. Value is the Job configuration.
+  # Each Job inherits `image`, `imagePullSecrets`, `automountServiceAccountToken`,
+  # `containerSecurityContext` and `securityContext` from `deployment` unless overridden,
+  # and mounts the chart-managed PVC when `persistence.enabled` and `persistence.mountPVC` are set.
+  # Set `inheritFromDeployment: false` on a Job to opt out of the inherited defaults.
   # See values for more details.
   # @section -- Job Parameters
   jobs:
     # db-migration:
+    #   inheritFromDeployment: true
     #   additionalPodAnnotations:
     #     helm.sh/hook: "pre-install,pre-upgrade"
     #     helm.sh/hook-weight: "-1"


### PR DESCRIPTION
## What

Jobs now inherit their defaults from `.Values.deployment` and can mount the chart-managed PVC.

## Why

Two rough edges when using `job.jobs` today:

1. **Everything must be repeated.** A Job that runs the same image as the Deployment still has to redeclare `image.repository`, `image.tag`, `image.digest`, `imagePullSecrets` and both security contexts. On a chart where the image tag is templated per environment, that duplication drifts — the Deployment gets bumped and the migration Job silently keeps running the old tag.
2. **Jobs can't see the PVC.** `persistence.enabled` + `persistence.mountPVC` wires the volume into the Deployment only. A Job that needs the same volume (seeding, migration, backup) has no way to reach it beyond hand-writing the `persistentVolumeClaim` volume and hardcoding the generated claim name.

## How

### Inheritance

Each Job inherits the following from `.Values.deployment`:

| Inherited | Note |
|---|---|
| `image.repository`, `image.tag`, `image.digest` | only when the Job sets no `image.repository` of its own |
| `image.pullPolicy` | always applied as the Job container's `imagePullPolicy` default |
| `imagePullSecrets` | |
| `automountServiceAccountToken` | |
| `containerSecurityContext` | |
| `securityContext` (pod level) | |

Any value set on the Job wins. `inheritFromDeployment: false` opts a Job out entirely.

The inheritance is deliberately narrow — `env`, `envFrom`, `resources`, scheduling and probes are **not** inherited, since a batch workload rarely wants the serving workload's values for those.

### Persistence

When `persistence.enabled` and `persistence.mountPVC` are true, each Job gets:

- a `volumeMounts` entry at `persistence.mountPath`
- a `volumes` entry using `persistence.name`, falling back to `<application.name>-data`

This mirrors the existing Deployment logic. Job-specific `volumes` / `volumeMounts` are preserved and appended after the PVC entries.

### Example

```yaml
deployment:
  image:
    repository: reg/app
    tag: v1.2.3
    pullPolicy: Always
  imagePullSecrets:
    - name: docker-pull
persistence:
  enabled: true
  mountPVC: true
  mountPath: /data
job:
  enabled: true
  jobs:
    db-migration:
      command: ["/bin/sh", "-c", "migrate"]
```

The Job renders with `reg/app:v1.2.3`, `imagePullPolicy: Always`, the Deployment's pull secrets and security contexts, and `/data` backed by the chart PVC — with no per-Job duplication.

## Behaviour changes

Two rendered-output changes that existing users will notice:

1. **Jobs now inherit `containerSecurityContext`.** With chart defaults (`readOnlyRootFilesystem: true`, `runAsNonRoot: true`), a Job that previously rendered no container `securityContext` now gets one. A Job writing to the container filesystem without a writable volume will now fail until it sets its own `containerSecurityContext` or `inheritFromDeployment: false`.
2. **Jobs now render an inherited `imagePullPolicy`.** Reflected in the updated `common_test` snapshot.

Both are the intended effect of the change rather than incidental, but they are behaviour changes, so flagging them explicitly for the release notes. Happy to gate the whole feature behind an opt-in flag (default `false`) instead if you'd prefer a strictly additive change — it's a one-line flip of the `inheritFromDeployment` default.

## Testing

- 9 new cases in `application/tests/job_test.yaml` covering inheritance, per-Job overrides, the opt-out, PVC mounting, custom claim name, coexistence with Job volumes, and the `mountPVC: false` case
- `helm unittest application` — 404 passed, 37 snapshots passed
- `helm lint application` — pass
- Feature enabled in `application/ci/values.yaml` (`persistence.mountPVC: true`, `mountPath: /data`) per CONTRIBUTING, snapshots regenerated
- Rendered the defaults / base / CRD profiles; all parse and validate
- `kubeconform -strict` against Kubernetes v1.31, v1.33 and v1.35 on the base profile: 21 valid, 0 invalid

`application/Chart.yaml` is intentionally left untouched for the release automation to bump.
