### PR TITLE
feat: Support Istio Virtual Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,22 @@
 
 # Application
 
-Generic Helm chart for deploying stateless applications on Kubernetes. Supports Deployments, Jobs, and CronJobs along with common companion resources (Services, Ingress, RBAC, autoscaling, monitoring, certificates, and more).
+Generic helm chart for applications which:
+
+- are stateless
+- creates only namespace scoped resources (e.g. it doesn't need CRB - Cluster Role Bindings)
+- don't need privileged containers
+- don't call the underlying Kubernetes API or use the underlying etcd as a database by defining custom resources
+- run either as deployment, job or cronjob
 
 ## Installing the Chart
 
-### From the OCI registry
-
-```shell
-helm install my-application oci://ghcr.io/stakater/charts/application --namespace test
-# or, to install a specific version
-helm install my-application oci://ghcr.io/stakater/charts/application --version <version> --namespace test
-```
-
-### From the Helm repository (deprecated)
-
-> **Note:** The Helm repository is deprecated in favor of the OCI registry above.
+To install the chart with the release name `my-application` in namespace `test`:
 
 ```shell
 helm repo add stakater https://stakater.github.io/stakater-charts
 helm repo update
 helm install my-application stakater/application --namespace test
-# or, to install a specific version
-helm install my-application stakater/application --version <version> --namespace test
 ```
 
 ## Uninstall the Chart
@@ -34,84 +28,67 @@ To uninstall the chart:
 helm delete --namespace test my-application
 ```
 
-## CI scope
-
-The CI validates the chart against upstream Kubernetes using Helm and Kind. These jobs should be configured as required status checks in branch protection rules.
-
-Server-side API validation runs against Kubernetes v1.31, v1.33, and v1.35. The chart uses `Capabilities.APIVersions` fallbacks for legacy APIs (`batch/v1beta1`, `policy/v1beta1`, `autoscaling/v2beta2`), but these were removed from Kubernetes before v1.25. Only the stable API paths are exercised in CI.
-
-Kind validation uses a Kubernetes-compatible values profile that excludes non-standard resources (CRDs, OpenShift routes, etc.). Resources that depend on CRDs or platform-specific APIs are only validated as template rendering (no server-side check).
-
-## Values Schema
-
-The chart ships with a [JSON Schema](application/values.schema.json) for `values.yaml` validation. When using an editor that supports JSON Schema (e.g. VS Code with the YAML extension), you get autocompletion and inline validation out of the box.
-
-## Contributing
-
-Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to set up your local environment and submit changes.
-
 ## Values
 
 ### Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| namespaceOverride | string, null | `""` | Override the namespace for all resources. |
-| componentOverride | string, null | `""` | Override the component label for all resources. |
-| partOfOverride | string, null | `""` | Override the partOf label for all resources. |
-| applicationName | string, null | `{{ .Release.Name }}` | Application name. Used as a prefix for all resource names. |
-| additionalLabels | object, null | `nil` | Additional labels for all resources. Keys and values are evaluated as templates. |
-| extraObjects | list, object, null | `nil` | Extra K8s manifests to deploy. Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are evaluated as templates. |
+| namespaceOverride | string | `""` | Override the namespace for all resources. |
+| componentOverride | string | `""` | Override the component label for all resources. |
+| partOfOverride | string | `""` | Override the partOf label for all resources. |
+| applicationName | string | `{{ .Chart.Name }}` | Application name. |
+| additionalLabels | tpl/object | `nil` | Additional labels for all resources. |
+| extraObjects | [list or object] of [tpl/object or tpl/string] | `nil` | Extra K8s manifests to deploy. Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are passed through tpl to render. |
 
 ### CronJob Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cronJob.enabled | bool | `false` | Deploy CronJob resources. |
-| cronJob.jobs | object, null | `nil` | Map of CronJob resources. Key will be used as a name suffix for the CronJob. Value is the CronJob configuration. See values for more details. |
+| cronJob.jobs | object | `nil` | Map of CronJob resources. Key will be used as a name suffix for the CronJob. Value is the CronJob configuration. See values for more details. |
 
 ### Job Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | job.enabled | bool | `false` | Deploy Job resources. |
-| job.jobs | object, null | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details. |
+| job.jobs | object | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details. |
 
 ### Deployment Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deployment.enabled | bool | `true` | Enable Deployment. |
-| deployment.additionalLabels | object, null | `nil` | Additional labels for Deployment. |
-| deployment.podLabels | object, null | `nil` | Additional pod labels which are used in Service's Label Selector. |
-| deployment.annotations | object, null | `nil` | Annotations for Deployment. |
-| deployment.additionalPodAnnotations | object, null | `nil` | Additional pod annotations. |
+| deployment.additionalLabels | object | `nil` | Additional labels for Deployment. |
+| deployment.podLabels | object | `nil` | Additional pod labels which are used in Service's Label Selector. |
+| deployment.annotations | object | `nil` | Annotations for Deployment. |
+| deployment.additionalPodAnnotations | object | `nil` | Additional pod annotations. |
 | deployment.strategy.type | string | `"RollingUpdate"` | Type of deployment strategy. |
 | deployment.reloadOnChange | bool | `true` | Reload deployment if attached Secret/ConfigMap changes. |
-| deployment.nodeSelector | object, null | `nil` | Select the node where the pods should be scheduled. |
-| deployment.hostAliases | list, null | `nil` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files. |
-| deployment.initContainers | object, null | `nil` | Add init containers to the pods. |
-| deployment.fluentdConfigAnnotations | object, null | `nil` | Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>. |
-| deployment.replicas | int, null | `nil` | Number of replicas. |
+| deployment.nodeSelector | object | `nil` | Select the node where the pods should be scheduled. |
+| deployment.hostAliases | list | `nil` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files. |
+| deployment.initContainers | object | `nil` | Add init containers to the pods. |
+| deployment.fluentdConfigAnnotations | object | `nil` | Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>. |
+| deployment.replicas | int | `nil` | Number of replicas. |
 | deployment.imagePullSecrets | list | `[]` | List of secrets to be used for pulling the images. |
-| deployment.envFrom | object, null | `nil` | Mount environment variables from ConfigMap or Secret to the pod. Use `nameSuffix` for resources managed by this chart (name will be prefixed with application name), or `name` to reference an existing external ConfigMap or Secret not managed by this chart. See the README "Consuming environment variable in application chart" section for more details. |
-| deployment.env | object, null | `nil` | Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details. |
-| deployment.volumes | object, null | `nil` | Volumes to be added to the pod. Key is the name of the volume. Value is the volume definition. |
-| deployment.volumeMounts | object, null | `nil` | Mount path for Volumes. Key is the name of the volume. Value is the volume mount definition. |
-| deployment.priorityClassName | string, null | `""` | Define the priority class for the pod. |
-| deployment.runtimeClassName | string, null | `""` | Set the runtimeClassName for the deployment's pods. |
-| deployment.tolerations | list, null | `nil` | Taint tolerations for the pods. |
-| deployment.affinity | object, null | `nil` | Affinity for the pods. |
-| deployment.topologySpreadConstraints | list, null | `nil` | Topology spread constraints for the pods. |
+| deployment.envFrom | object | `nil` | Mount environment variables from ConfigMap or Secret to the pod. See the README "Consuming environment variable in application chart" section for more details. |
+| deployment.env | object | `nil` | Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details. |
+| deployment.volumes | object | `nil` | Volumes to be added to the pod. Key is the name of the volume. Value is the volume definition. |
+| deployment.volumeMounts | object | `nil` | Mount path for Volumes. Key is the name of the volume. Value is the volume mount definition. |
+| deployment.priorityClassName | string | `""` | Define the priority class for the pod. |
+| deployment.runtimeClassName | string | `""` | Set the runtimeClassName for the deployment's pods. |
+| deployment.tolerations | list | `nil` | Taint tolerations for the pods. |
+| deployment.affinity | object | `nil` | Affinity for the pods. |
+| deployment.topologySpreadConstraints | list | `nil` | Topology spread constraints for the pods. |
 | deployment.revisionHistoryLimit | int | `2` | Number of ReplicaSet revisions to retain. |
-| deployment.image.repository | tpl | `""` | Repository. |
-| deployment.image.tag | tpl | `""` | Tag. |
-| deployment.image.digest | tpl | `""` | Image digest. If resolved to a non-empty value, digest takes precedence on the tag. |
+| deployment.image.repository | tpl/string | `""` | Repository. |
+| deployment.image.tag | tpl/string | `""` | Tag. |
+| deployment.image.digest | tpl/string | `""` | Image digest. If resolved to a non-empty value, digest takes precedence on the tag. |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
-| deployment.dnsConfig | object, null | `nil` | DNS config for the pods. |
-| deployment.dnsPolicy | string, null | `""` | DNS Policy. |
-| deployment.enableServiceLinks | bool | `true` | Enable Kubernetes service links. |
-| deployment.startupProbe | object, null | See below | Startup probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.dnsConfig | object | `nil` | DNS config for the pods. |
+| deployment.dnsPolicy | string | `""` | DNS Policy. |
+| deployment.startupProbe | object | See below | Startup probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.startupProbe.enabled | bool | `false` | Enable Startup probe. |
 | deployment.startupProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.startupProbe.periodSeconds | int | `10` | Time between retries. |
@@ -121,7 +98,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.startupProbe.exec | object | `{}` | Exec probe. |
 | deployment.startupProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.startupProbe.grpc | object | `{}` | gRPC probe. |
-| deployment.readinessProbe | object, null | See below | Readiness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.readinessProbe | object | See below | Readiness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.readinessProbe.enabled | bool | `false` | Enable Readiness probe. |
 | deployment.readinessProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.readinessProbe.periodSeconds | int | `10` | Time between retries. |
@@ -131,7 +108,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.readinessProbe.exec | object | `{}` | Exec probe. |
 | deployment.readinessProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.readinessProbe.grpc | object | `{}` | gRPC probe. |
-| deployment.livenessProbe | object, null | See below | Liveness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.livenessProbe | object | See below | Liveness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.livenessProbe.enabled | bool | `false` | Enable Liveness probe. |
 | deployment.livenessProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.livenessProbe.periodSeconds | int | `10` | Time between retries. |
@@ -142,124 +119,125 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | deployment.livenessProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.livenessProbe.grpc | object | `{}` | gRPC probe. |
 | deployment.resources | object | `{}` | Resource limits and requests for the pod. |
-| deployment.containerSecurityContext | object, null | `{"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
+| deployment.containerSecurityContext | object | `{"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
 | deployment.openshiftOAuthProxy.enabled | bool | `false` | Enable [OpenShift OAuth Proxy](https://github.com/openshift/oauth-proxy). |
 | deployment.openshiftOAuthProxy.port | int | `8080` | Port on which application is running inside container. |
 | deployment.openshiftOAuthProxy.secretName | string | `"openshift-oauth-proxy-tls"` | Secret name for the OAuth Proxy TLS certificate. |
-| deployment.openshiftOAuthProxy.image | string | `"quay.io/openshift/origin-oauth-proxy:latest@sha256:35967c4d152d7b21167e3ba0aae57e29d3a46a75a738329073ef2227cbc33bde"` | Image for the OAuth Proxy. |
+| deployment.openshiftOAuthProxy.image | string | `"openshift/oauth-proxy:latest"` | Image for the OAuth Proxy. |
 | deployment.openshiftOAuthProxy.disableTLSArg | bool | `false` | If disabled `--http-address=:8081` will be used instead of `--https-address=:8443`. It can be useful when an ingress is enabled for the application. |
-| deployment.securityContext | object, null | `nil` | Security Context for the pod. |
+| deployment.securityContext | object | `nil` | Security Context for the pod. |
 | deployment.command | list | `[]` | Command for the app container. |
 | deployment.args | list | `[]` | Args for the app container. |
-| deployment.automountServiceAccountToken | bool | `false` | Mount Service Account token. |
-| deployment.ports | list, null | `nil` | List of ports for the app container. |
-| deployment.hostNetwork | bool, null | `nil` | Host network connectivity. |
-| deployment.terminationGracePeriodSeconds | int, null | `nil` | Gracefull termination period. |
-| deployment.minReadySeconds | int, null | `nil` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing. |
+| deployment.automountServiceAccountToken | bool | `true` | Mount Service Account token. |
+| deployment.ports | list | `nil` | List of ports for the app container. |
+| deployment.hostNetwork | bool | `nil` | Host network connectivity. |
+| deployment.terminationGracePeriodSeconds | int | `nil` | Gracefull termination period. |
+| deployment.minReadySeconds | int | `nil` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing. |
 | deployment.lifecycle | object | `{}` | Lifecycle configuration for the pod. |
-| deployment.additionalContainers | list, object, null | `nil` | Additional containers besides init and app containers (without templating). Supports both list and map formats. Map format makes overrides easier (e.g. ArgoCD). |
+| deployment.additionalContainers | list | `nil` | Additional containers besides init and app containers (without templating). |
 | persistence.enabled | bool | `false` | Enable persistence. |
 | persistence.mountPVC | bool | `false` | Whether to mount the created PVC to the deployment. |
 | persistence.mountPath | string | `"/"` | If `persistence.mountPVC` is enabled, where to mount the volume in the containers. |
-| persistence.name | string, null | `{{ include "application.name" $ }}-data` | Name of the PVC. |
+| persistence.name | string | `{{ include "application.name" $ }}-data` | Name of the PVC. |
 | persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for volume. |
-| persistence.storageClass | string, null | `nil` | Storage class for volume. If defined, use that value If set to "-" or "", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner. |
-| persistence.additionalLabels | object, null | `nil` | Additional labels for persistent volume. |
-| persistence.annotations | object, null | `nil` | Annotations for persistent volume. |
+| persistence.storageClass | string | `nil` | Storage class for volume. If defined, use that value If set to "-" or "", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner. |
+| persistence.additionalLabels | object | `nil` | Additional labels for persistent volume. |
+| persistence.annotations | object | `nil` | Annotations for persistent volume. |
 | persistence.storageSize | string | `"8Gi"` | Size of the persistent volume. |
-| persistence.volumeMode | string, null | `""` | PVC Volume Mode. |
-| persistence.volumeName | string, null | `""` | Name of the volume. |
+| persistence.volumeMode | string | `""` | PVC Volume Mode. |
+| persistence.volumeName | string | `""` | Name of the volume. |
 
 ### Service Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | service.enabled | bool | `true` | Enable Service. |
-| service.additionalLabels | object, null | `nil` | Additional labels for service. |
-| service.annotations | object, null | `nil` | Annotations for service. |
+| service.additionalLabels | object | `nil` | Additional labels for service. |
+| service.annotations | object | `nil` | Annotations for service. |
 | service.ports | list | `[{"name":"http","port":8080,"protocol":"TCP","targetPort":8080}]` | Ports for applications service. |
-| service.ports[0].targetPort | int, string, null | `8080` | Target port on pods. Accepts port number or port name (IANA_SVC_NAME). |
 | service.type | string | `"ClusterIP"` | Type of service. |
-| service.clusterIP | string, null | `nil` | Fixed IP for a ClusterIP service. Set to `None` for an headless service |
-| service.loadBalancerClass | string, null | `nil` | LoadBalancer class name for LoadBalancer type services. |
+| service.clusterIP | string | `nil` | Fixed IP for a ClusterIP service. Set to `None` for an headless service |
+| service.loadBalancerClass | string | `nil` | LoadBalancer class name for LoadBalancer type services. |
 
 ### Ingress Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | ingress.enabled | bool | `false` | Enable Ingress. |
-| ingress.ingressClassName | string, null | `""` | Name of the ingress class. |
-| ingress.hosts[0].host | tpl | `"chart-example.local"` | Hostname. |
+| ingress.ingressClassName | string | `""` | Name of the ingress class. |
+| ingress.hosts[0].host | tpl/string | `"chart-example.local"` | Hostname. |
 | ingress.hosts[0].paths[0].path | string | `"/"` | Path. |
-| ingress.hosts[0].paths[0].pathType | string, null | `ImplementationSpecific` | Path type. |
-| ingress.hosts[0].paths[0].serviceName | string, null | `{{ include "application.name" $ }}` | Service name. |
-| ingress.hosts[0].paths[0].servicePort | string, null | `http` | Service port. |
-| ingress.additionalLabels | object, null | `nil` | Additional labels for ingress. |
-| ingress.annotations | object, null | `nil` | Annotations for ingress. |
-| ingress.tls | list, null | `nil` | TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret. |
+| ingress.hosts[0].paths[0].pathType | string | `ImplementationSpecific` | Path type. |
+| ingress.hosts[0].paths[0].serviceName | string | `{{ include "application.name" $ }}` | Service name. |
+| ingress.hosts[0].paths[0].servicePort | string | `http` | Service port. |
+| ingress.additionalLabels | object | `nil` | Additional labels for ingress. |
+| ingress.annotations | object | `nil` | Annotations for ingress. |
+| ingress.tls | list | `nil` | TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret. |
+
+### VirtualService Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| virtualService.enabled | bool | `false` | Deploy an Istio VirtualService resource. Requires Istio to be installed in the cluster (networking.istio.io CRDs). Uses networking.istio.io/v1 if available, falls back to v1beta1. |
+| virtualService.hosts | list | `[]` | Hostnames this VirtualService applies to. Can be a DNS name, wildcard (*.example.com), or short name (resolved relative to the VS namespace). |
+| virtualService.gateways | list | `[]` | Gateways this VirtualService is bound to. Use <namespace>/<name> format (e.g. istio-system/istio-gateway). Omit to apply rules to mesh-internal sidecar traffic only (mesh gateway). |
+| virtualService.exportTo | list, null | `[]` | Namespaces this VirtualService is exported to. "." = same namespace only, "*" = all namespaces (default when omitted). |
+| virtualService.http | list | `[]` | Ordered HTTP route rules. First matching rule wins. Supports the full Istio HTTPRoute spec: match, route, rewrite, redirect, retries, timeout, fault, corsPolicy, headers, mirror, directResponse, delegate. |
+| virtualService.tls | list | `[]` | Ordered TLS route rules for non-terminated TLS/HTTPS (SNI-based routing). |
+| virtualService.tcp | list | `[]` | Ordered TCP route rules for opaque TCP traffic (non-HTTP, non-TLS ports). |
+| virtualService.routes | object, null | `{}` | Multiple VirtualServices — use when you need more than one VS for this app (e.g. external gateway + internal mesh-only rules). Each key produces a separate VS named <app>-<key>. Each entry supports the same fields as the top-level (hosts, gateways, exportTo, http, tls, tcp). When routes is set, the top-level hosts/gateways/http/tls/tcp fields are ignored. |
 
 ### HTTPRoute Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | httpRoute.enabled | bool | `false` | Enable HTTPRoute (Gateway API). |
-| httpRoute.parentRefs | list, null | `nil` | Parent references for the HTTPRoute. Keys and values are evaluated as templates. |
-| httpRoute.useDefaultGateways | string, null | `nil` | The default Gateway scope to use for this Route. If unset (the default) or set to None, the Route will not be attached to any default Gateway; if set, it will be attached to any default Gateway supporting the named scope, subject to the usual rules about which Routes a Gateway is allowed to claim. |
-| httpRoute.gatewayNamespace | string, null | `""` | Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute. |
-| httpRoute.hostnames | list, null | `nil` | Hostnames for the HTTPRoute. Values are evaluated as templates. |
+| httpRoute.parentRefs | tpl/list | `nil` | Parent references for the HTTPRoute. |
+| httpRoute.useDefaultGateways | string | `nil` | The default Gateway scope to use for this Route. If unset (the default) or set to None, the Route will not be attached to any default Gateway; if set, it will be attached to any default Gateway supporting the named scope, subject to the usual rules about which Routes a Gateway is allowed to claim. |
+| httpRoute.gatewayNamespace | string | `""` | Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute. |
+| httpRoute.hostnames | tpl/list | `nil` | Hostnames for the HTTPRoute. |
 | httpRoute.additionalLabels | object | `{}` | Additional labels for HTTPRoute. |
 | httpRoute.annotations | object | `{}` | Annotations for HTTPRoute. |
-| httpRoute.rules | list | `[{"backendRefs":[{"name":"{{ include \"application.name\" $ }}","port":"{{ (first $.Values.service.ports).port }}"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. Keys and values are evaluated as templates. |
-| httpRoute.rules[0].backendRefs[0].port | int, tpl, null | `"{{ (first $.Values.service.ports).port }}"` | Port number or template expression for the backend service. Required when the referent is a Kubernetes Service (the default kind); optional for other kinds such as ServiceImport, where it is omitted from the manifest when unset or when a template expression renders empty. |
-
-### ListenerSet Parameters
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| listenerSet.enabled | bool | `false` | Enable ListenerSet (Gateway API). |
-| listenerSet.listeners | list, null | `nil` | Logical endpoints that are bound on this referenced parent Gateway's addresses. Keys and values are evaluated as templates. |
-| listenerSet.parentRef | object, null | `nil` | Parent Gateway reference for the ListenerSet. Keys and values are evaluated as templates. |
-| listenerSet.additionalLabels | object | `{}` | Additional labels for ListenerSet. |
-| listenerSet.annotations | object | `{}` | Annotations for ListenerSet. |
+| httpRoute.rules | tpl/list | `[{"backendRefs":[{"name":"{{ include \"application.name\" $ }}","port":"{{ (first $.Values.service.ports).port | int }}"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. |
 
 ### Route Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | route.enabled | bool | `false` | Deploy a Route (OpenShift) resource. |
-| route.additionalLabels | object, null | `nil` | Additional labels for Route. |
-| route.annotations | object, null | `nil` | Annotations for Route. |
-| route.host | string, null | `nil` | Explicit host. If no host is added then openshift inserts the default hostname. |
-| route.path | string, null | `nil` | Path. |
-| route.port | object, null | `{"targetPort":"http"}` | Service port. |
+| route.additionalLabels | object | `nil` | Additional labels for Route. |
+| route.annotations | object | `nil` | Annotations for Route. |
+| route.host | string | `nil` | Explicit host. If no host is added then openshift inserts the default hostname. |
+| route.path | string | `nil` | Path. |
+| route.port | object | `{"targetPort":"http"}` | Service port. |
 | route.to.weight | int | `100` | Service weight. |
 | route.wildcardPolicy | string | `"None"` | Wildcard policy. |
 | route.tls.termination | string | `"edge"` | TLS termination strategy. |
 | route.tls.insecureEdgeTerminationPolicy | string | `"Redirect"` | TLS insecure termination policy. |
-| route.alternateBackends | object, null | `nil` | Alternate backend with it's weight. |
+| route.alternateBackends | list | `nil` | Alternate backend with it's weight. |
 
 ### SecretProviderClass Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | secretProviderClass.enabled | bool | `false` | Deploy a [Secrets Store CSI Driver SecretProviderClass](https://secrets-store-csi-driver.sigs.k8s.io/) resource. |
-| secretProviderClass.name | string, null | `""` | Name of the SecretProviderClass. Required if `secretProviderClass.enabled` is set to `true`. |
-| secretProviderClass.provider | string, null | `""` | Name of the provider. Required if `secretProviderClass.enabled` is set to `true`. |
-| secretProviderClass.vaultAddress | string, null | `""` | Vault Address. Required if `secretProviderClass.provider` is set to `vault`. |
-| secretProviderClass.roleName | tpl | `""` | Vault Role Name. Required if `secretProviderClass.provider` is set to `vault`. |
-| secretProviderClass.objects | string, null | `nil` | Objects definitions. |
-| secretProviderClass.secretObjects | list, null | `nil` | Objects mapping. |
+| secretProviderClass.name | string | `""` | Name of the SecretProviderClass. Required if `secretProviderClass.enabled` is set to `true`. |
+| secretProviderClass.provider | string | `""` | Name of the provider. Required if `secretProviderClass.enabled` is set to `true`. |
+| secretProviderClass.vaultAddress | string | `""` | Vault Address. Required if `secretProviderClass.provider` is set to `vault`. |
+| secretProviderClass.roleName | tpl/string | `""` | Vault Role Name. Required if `secretProviderClass.provider` is set to `vault`. |
+| secretProviderClass.objects | list | `nil` | Objects definitions. |
+| secretProviderClass.secretObjects | list | `nil` | Objects mapping. |
 
 ### ForecastleApp Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | forecastle.enabled | bool | `false` | Deploy a [ForecastleApp](https://github.com/stakater/Forecastle) resource. |
-| forecastle.additionalLabels | object, null | `nil` | Additional labels for ForecastleApp. |
+| forecastle.additionalLabels | object | `nil` | Additional labels for ForecastleApp. |
 | forecastle.icon | string | `"https://raw.githubusercontent.com/stakater/ForecastleIcons/master/stakater-big.png"` | Icon URL. |
-| forecastle.displayName | string, null | `""` | Application Name. Required if `forecastle.enabled` is set to `true`. |
-| forecastle.group | string, null | `{{ .Release.Namespace }}` | Application Group. |
-| forecastle.properties | object, null | `nil` | Custom properties. |
+| forecastle.displayName | string | `""` | Application Name. Required if `forecastle.enabled` is set to `true`. |
+| forecastle.group | string | `{{ .Release.Namespace }}` | Application Group. |
+| forecastle.properties | object | `nil` | Custom properties. |
 | forecastle.networkRestricted | bool | `false` | Is application network restricted?. |
 
 ### RBAC Parameters
@@ -267,49 +245,46 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | rbac.enabled | bool | `true` | Enable RBAC. |
-| rbac.serviceAccount.create | bool | `false` | Specifies whether to create a dedicated service account. If set to `true`, a new service account will be created. |
-| rbac.serviceAccount.name | string, null | `""` | The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`: If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account ("default") is used. If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used. If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template. If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation. |
-| rbac.serviceAccount.additionalLabels | object, null | `nil` | Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account. |
-| rbac.serviceAccount.annotations | object, null | `nil` | Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account. |
-| rbac.roles | list, null | `nil` | Role definitions scoped to a single namespace. |
-| rbac.clusterRoles | list, null | `nil` | ClusterRole definitions with cluster-wide permissions. |
-| rbac.additionalLabels | object, null | `nil` | Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
-| rbac.annotations | object, null | `nil` | Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
+| rbac.serviceAccount.enabled | bool | `false` | Deploy Service Account. |
+| rbac.serviceAccount.name | string | `{{ include "application.name" $ }}` | Service Account Name. |
+| rbac.serviceAccount.additionalLabels | object | `nil` | Additional labels for Service Account. |
+| rbac.serviceAccount.annotations | object | `nil` | Annotations for Service Account. |
+| rbac.roles | list | `nil` | Namespaced Roles. |
 
 ### ConfigMap Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | configMap.enabled | bool | `false` | Deploy additional ConfigMaps. |
-| configMap.additionalLabels | object, null | `nil` | Additional labels for ConfigMaps. |
-| configMap.annotations | object, null | `nil` | Annotations for ConfigMaps. |
-| configMap.files | object, null | `nil` | List of ConfigMap entries. Key will be used as a name suffix for the ConfigMap. Value is the ConfigMap content. |
+| configMap.additionalLabels | object | `nil` | Additional labels for ConfigMaps. |
+| configMap.annotations | object | `nil` | Annotations for ConfigMaps. |
+| configMap.files | object | `nil` | List of ConfigMap entries. Key will be used as a name suffix for the ConfigMap. Value is the ConfigMap content. |
 
 ### SealedSecret Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | sealedSecret.enabled | bool | `false` | Deploy [SealedSecret](https://github.com/bitnami-labs/sealed-secrets) resources. |
-| sealedSecret.additionalLabels | object, null | `nil` | Additional labels for SealedSecret. |
-| sealedSecret.annotations | object, null | `nil` | Annotations for SealedSecret. |
-| sealedSecret.files | object, null | `nil` | List of SealedSecret entries. Key will be used as a name suffix for the SealedSecret. Value is the SealedSecret content. |
+| sealedSecret.additionalLabels | object | `nil` | Additional labels for SealedSecret. |
+| sealedSecret.annotations | object | `nil` | Annotations for SealedSecret. |
+| sealedSecret.files | object | `nil` | List of SealedSecret entries. Key will be used as a name suffix for the SealedSecret. Value is the SealedSecret content. |
 
 ### Secret Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | secret.enabled | bool | `false` | Deploy additional Secret resources. |
-| secret.additionalLabels | object, null | `nil` | Additional labels for Secret. |
-| secret.annotations | object, null | `nil` | Annotations for Secret. |
-| secret.files | object, null | `nil` | List of Secrets entries. Key will be used as a name suffix for the Secret. There a three allowed modes: - `data`: Data is base64 encoded by the chart - `encodedData`: Use raw values (already base64ed) inside the data map - `stringData`: Use raw values inside the stringData map |
+| secret.additionalLabels | object | `nil` | Additional labels for Secret. |
+| secret.annotations | object | `nil` | Annotations for Secret. |
+| secret.files | object | `nil` | List of Secrets entries. Key will be used as a name suffix for the Secret. There a three allowed modes: - `data`: Data is base64 encoded by the chart - `encodedData`: Use raw values (already base64ed) inside the data map - `stringData`: Use raw values inside the stringData map |
 
 ### ServiceMonitor Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | serviceMonitor.enabled | bool | `false` | Deploy a ServiceMonitor (Prometheus Operator) resource. |
-| serviceMonitor.additionalLabels | object, null | `nil` | Additional labels for ServiceMonitor. |
-| serviceMonitor.annotations | object, null | `nil` | Annotations for ServiceMonitor. |
+| serviceMonitor.additionalLabels | object | `nil` | Additional labels for ServiceMonitor. |
+| serviceMonitor.annotations | object | `nil` | Annotations for ServiceMonitor. |
 | serviceMonitor.endpoints | list | `[{"interval":"5s","path":"/actuator/prometheus","port":"http"}]` | Service endpoints from which prometheus will scrape data. |
 
 ### Autoscaling - Horizontal Pod Autoscaling Parameters
@@ -317,8 +292,8 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaling. |
-| autoscaling.additionalLabels | object, null | `nil` | Additional labels for HPA. |
-| autoscaling.annotations | object, null | `nil` | Annotations for HPA. |
+| autoscaling.additionalLabels | object | `nil` | Additional labels for HPA. |
+| autoscaling.annotations | object | `nil` | Annotations for HPA. |
 | autoscaling.minReplicas | int | `1` | Minimum number of replicas. |
 | autoscaling.maxReplicas | int | `10` | Maximum number of replicas. |
 | autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":60,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":60,"type":"Utilization"}},"type":"Resource"}]` | Metrics used for autoscaling. |
@@ -328,40 +303,40 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaling. |
-| vpa.additionalLabels | object, null | `nil` | Additional labels for VPA. |
-| vpa.annotations | object, null | `nil` | Annotations for VPA. |
+| vpa.additionalLabels | object | `nil` | Additional labels for VPA. |
+| vpa.annotations | object | `nil` | Annotations for VPA. |
 | vpa.containerPolicies | list | `[]` | Container policies for individual containers. |
-| vpa.updatePolicy | object, null | `{"updateMode":"Auto"}` | Update policy. |
+| vpa.updatePolicy | object | `{"updateMode":"Auto"}` | Update policy. |
 
 ### EndpointMonitor Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | endpointMonitor.enabled | bool | `false` | Deploy an [IMC EndpointMonitor](https://github.com/stakater/IngressMonitorController) resource. |
-| endpointMonitor.additionalLabels | object, null | `nil` | Additional labels for EndpointMonitor. |
-| endpointMonitor.annotations | object, null | `nil` | Annotations for EndpointMonitor. |
+| endpointMonitor.additionalLabels | object | `nil` | Additional labels for EndpointMonitor. |
+| endpointMonitor.annotations | object | `nil` | Annotations for EndpointMonitor. |
 
 ### cert-manager Certificate Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | certificate.enabled | bool | `false` | Deploy a [cert-manager Certificate](https://cert-manager.io) resource. |
-| certificate.additionalLabels | object, null | `nil` | Additional labels for Certificate. |
-| certificate.annotations | object, null | `nil` | Annotations for Certificate. |
-| certificate.secretName | tpl | `"tls-cert"` | Name of the secret resource that will be automatically created and managed by this Certificate resource. |
+| certificate.additionalLabels | object | `nil` | Additional labels for Certificate. |
+| certificate.annotations | object | `nil` | Annotations for Certificate. |
+| certificate.secretName | tpl/string | `"tls-cert"` | Name of the secret resource that will be automatically created and managed by this Certificate resource. |
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
-| certificate.subject | object, null | `nil` | Full X509 name specification for certificate. Keys and values are evaluated as templates. |
-| certificate.commonName | tpl, null | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
+| certificate.subject | tpl/object | `nil` | Full X509 name specification for certificate. |
+| certificate.commonName | tpl/string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
 | certificate.keyAlgorithm | string | `"RSA"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"PKCS1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |
 | certificate.isCA | bool | `false` | Mark this Certificate as valid for certificate signing. |
-| certificate.usages | list, null | `nil` | Set of x509 usages that are requested for the certificate. |
-| certificate.dnsNames | list, null | `nil` | List of DNS subjectAltNames to be set on the certificate. Keys and values are evaluated as templates. |
-| certificate.ipAddresses | list, null | `nil` | List of IP address subjectAltNames to be set on the certificate. |
-| certificate.uriSANs | list, null | `nil` | List of URI subjectAltNames to be set on the certificate. |
-| certificate.emailSANs | list, null | `nil` | List of email subjectAltNames to be set on the Certificate. |
+| certificate.usages | list | `nil` | Set of x509 usages that are requested for the certificate. |
+| certificate.dnsNames | tpl/list | `nil` | List of DNS subjectAltNames to be set on the certificate. |
+| certificate.ipAddresses | list | `nil` | List of IP address subjectAltNames to be set on the certificate. |
+| certificate.uriSANs | list | `nil` | List of URI subjectAltNames to be set on the certificate. |
+| certificate.emailSANs | list | `nil` | List of email subjectAltNames to be set on the Certificate. |
 | certificate.privateKey.enabled | bool | `false` | Enable Private Key for the certificate. |
 | certificate.privateKey.rotationPolicy | string | `"Always"` | Denotes how private keys should be generated or sourced when a certificate is being issued. |
 | certificate.issuerRef.name | string | `"ca-issuer"` | Reference to the issuer for this certificate. |
@@ -372,7 +347,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | certificate.keystores.pkcs12.key | string | `"test_key"` | Key of the entry in the Secret resource's data field to be used. |
 | certificate.keystores.pkcs12.name | string | `"test-creds"` | Name of the Secret resource being referred to. |
 | certificate.keystores.jks.create | bool | `false` | Enables jks keystore creation for the Certificate. JKS configures options for storing a JKS keystore in the spec.secretName Secret resource. |
-| certificate.keystores.jks.key | tpl | `"test_key"` | Key of the entry in the Secret resource's data field to be used. |
+| certificate.keystores.jks.key | tpl/string | `"test_key"` | Key of the entry in the Secret resource's data field to be used. |
 | certificate.keystores.jks.name | string | `"test-creds"` | Name of the Secret resource being referred to. |
 
 ### AlertmanagerConfig Parameters
@@ -380,9 +355,9 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | alertmanagerConfig.enabled | bool | `false` | Deploy an AlertmanagerConfig (Prometheus Operator) resource. |
-| alertmanagerConfig.selectionLabels | object, null | `{"alertmanagerConfig":"workload"}` | Labels to be picked up by Alertmanager to add it to base config. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html](OpenShift's AlermanagerConfig documentation) under .spec.alertmanagerConfigSelector. |
-| alertmanagerConfig.spec | object, null | `{"inhibitRules":[],"receivers":[],"route":null}` | AlertmanagerConfig spec. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html](OpenShift's AlermanagerConfig documentation). |
-| alertmanagerConfig.spec.route | object, null | `nil` | Route definition for alerts matching the resource’s namespace. It will be added to the generated Alertmanager configuration as a first-level route. |
+| alertmanagerConfig.selectionLabels | object | `{"alertmanagerConfig":"workload"}` | Labels to be picked up by Alertmanager to add it to base config. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html](OpenShift's AlermanagerConfig documentation) under .spec.alertmanagerConfigSelector. |
+| alertmanagerConfig.spec | object | `{"inhibitRules":[],"receivers":[],"route":null}` | AlertmanagerConfig spec. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html](OpenShift's AlermanagerConfig documentation). |
+| alertmanagerConfig.spec.route | object | `nil` | Route definition for alerts matching the resource’s namespace. It will be added to the generated Alertmanager configuration as a first-level route. |
 | alertmanagerConfig.spec.receivers | list | `[]` | List of receivers. |
 | alertmanagerConfig.spec.inhibitRules | list | `[]` | Inhibition rules that allows to mute alerts when other alerts are already firing. |
 
@@ -391,7 +366,7 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prometheusRule.enabled | bool | `false` | Deploy a PrometheusRule (Prometheus Operator) resource. |
-| prometheusRule.additionalLabels | object, null | `nil` | Additional labels for PrometheusRule. |
+| prometheusRule.additionalLabels | object | `nil` | Additional labels for PrometheusRule. |
 | prometheusRule.groups | list | `[]` | Groups with alerting rules. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/prometheusrule-monitoring-coreos-com-v1.html](OpenShift's PrometheusRule documentation). |
 
 ### ExternalSecret Parameters
@@ -399,65 +374,56 @@ Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | externalSecret.enabled | bool | `false` | Deploy [ExternalSecret](https://external-secrets.io/latest/) resources. |
-| externalSecret.additionalLabels | object, null | `nil` | Additional labels for ExternalSecret. |
-| externalSecret.annotations | object, null | `nil` | Annotations for ExternalSecret. |
-| externalSecret.secretStore | object, null | `{"kind":"SecretStore","name":"tenant-vault-secret-store"}` | Default values for the SecretStore. Can be overriden per ExternalSecret in the `externalSecret.files` object. |
+| externalSecret.additionalLabels | object | `nil` | Additional labels for ExternalSecret. |
+| externalSecret.annotations | object | `nil` | Annotations for ExternalSecret. |
+| externalSecret.secretStore | object | `{"kind":"SecretStore","name":"tenant-vault-secret-store"}` | Default values for the SecretStore. Can be overriden per ExternalSecret in the `externalSecret.files` object. |
 | externalSecret.secretStore.name | string | `"tenant-vault-secret-store"` | Name of the SecretStore to use. |
 | externalSecret.secretStore.kind | string | `"SecretStore"` | Kind of the SecretStore being refered to. |
 | externalSecret.refreshInterval | string | `"1m"` | RefreshInterval is the amount of time before the values are read again from the SecretStore provider. |
-| externalSecret.files | object, null | `nil` | List of ExternalSecret entries. Key will be used as a name suffix for the ExternalSecret. There a two allowed modes: - `data`: Data defines the connection between the Kubernetes Secret keys and the Provider data - `dataFrom`: Used to fetch all properties from the Provider key |
+| externalSecret.files | object | `nil` | List of ExternalSecret entries. Key will be used as a name suffix for the ExternalSecret. There a two allowed modes: - `data`: Data defines the connection between the Kubernetes Secret keys and the Provider data - `dataFrom`: Used to fetch all properties from the Provider key |
 
 ### NetworkPolicy Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | networkPolicy.enabled | bool | `false` | Enable Network Policy. |
-| networkPolicy.additionalLabels | object, null | `nil` | Additional labels for Network Policy. |
-| networkPolicy.annotations | object, null | `nil` | Annotations for Network Policy. |
-| networkPolicy.ingress | list, null | `nil` | Ingress rules for Network Policy. |
-| networkPolicy.egress | list, null | `nil` | Egress rules for Network Policy. |
+| networkPolicy.additionalLabels | object | `nil` | Additional labels for Network Policy. |
+| networkPolicy.annotations | object | `nil` | Annotations for Network Policy. |
+| networkPolicy.ingress | list | `nil` | Ingress rules for Network Policy. |
+| networkPolicy.egress | list | `nil` | Egress rules for Network Policy. |
 
 ### PodDisruptionBudget Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | pdb.enabled | bool | `false` | Enable Pod Disruption Budget. |
-| pdb.minAvailable | int, string, null | `1` | Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. "25%"). |
-| pdb.maxUnavailable | int, string, null | `nil` | Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. "25%"). |
+| pdb.minAvailable | int | `1` | Minimum number of pods that must be available after eviction. |
+| pdb.maxUnavailable | int | `nil` | Maximum number of unavailable pods during voluntary disruptions. |
 
 ### GrafanaDashboard Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | grafanaDashboard.enabled | bool | `false` | Deploy [GrafanaDashboard](https://github.com/grafana/grafana-operator) resources. |
-| grafanaDashboard.additionalLabels | object, null | `nil` | Additional labels for GrafanaDashboard. |
-| grafanaDashboard.annotations | object, null | `nil` | Annotations for GrafanaDashboard. |
-| grafanaDashboard.contents | object, null | `nil` | List of GrafanaDashboard entries. Key will be used as a name suffix for the GrafanaDashboard. Value is the GrafanaDashboard content. According to GrafanaDashboard behavior, `url` field takes precedence on the `json` field. |
+| grafanaDashboard.additionalLabels | object | `nil` | Additional labels for GrafanaDashboard. |
+| grafanaDashboard.annotations | object | `nil` | Annotations for GrafanaDashboard. |
+| grafanaDashboard.contents | object | `nil` | List of GrafanaDashboard entries. Key will be used as a name suffix for the GrafanaDashboard. Value is the GrafanaDashboard content. According to GrafanaDashboard behavior, `url` field takes precedence on the `json` field. |
 
 ### Backup Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backup.enabled | bool | `false` | Deploy a [Velero/OADP Backup](https://velero.io/docs/main/api-types/backup/) resource. |
-| backup.namespace | string, null | `{{ .Release.Namespace }}` | Namespace for Backup. |
-| backup.additionalLabels | object, null | `nil` | Additional labels for Backup. |
-| backup.annotations | object, null | `nil` | Annotations for Backup. |
-| backup.defaultVolumesToFsBackup | bool | `true` | Whether to use filesystem backup to take snapshots of all pod volumes by default. |
-| backup.defaultVolumesToRestic | bool, null | `nil` | Whether to use Restic to take snapshots of all pod volumes by default. Deprecated: Use `defaultVolumesToFsBackup` instead. |
+| backup.namespace | string | `{{ .Release.Namespace }}` | Namespace for Backup. |
+| backup.additionalLabels | object | `nil` | Additional labels for Backup. |
+| backup.annotations | object | `nil` | Annotations for Backup. |
+| backup.defaultVolumesToRestic | bool | `true` | Whether to use Restic to take snapshots of all pod volumes by default. |
 | backup.snapshotVolumes | bool | `true` | Whether to take snapshots of persistent volumes as part of the backup. |
-| backup.snapshotMoveData | bool, null | `nil` | Whether to move the data of the snapshot after it's taken. |
-| backup.csiSnapshotTimeout | string, null | `nil` | Time to wait for CSI VolumeSnapshot status to turn ReadyToUse during creation (e.g., "10m"). |
-| backup.datamover | string, null | `nil` | Data mover to be used by the backup. If empty or "velero", the built-in data mover will be used. |
-| backup.itemOperationTimeout | string, null | `nil` | Time to wait for asynchronous BackupItemAction operations (e.g., "1h"). |
-| backup.storageLocation | string, null | `nil` | Name of the backup storage location where the backup should be stored. |
+| backup.storageLocation | string | `nil` | Name of the backup storage location where the backup should be stored. |
 | backup.ttl | string | `"1h0m0s"` | How long the Backup should be retained for. |
-| backup.volumeSnapshotLocations | list, null | `nil` | Names of VolumeSnapshotLocations associated with this backup. |
-| backup.includedNamespaces | list, null | `[ {{ include "application.namespace" $ }} ]` | List of namespaces to include objects from. Values are evaluated as templates. |
-| backup.includedResources | list, null | `nil` | List of resource types to include in the backup. |
-| backup.excludedResources | list, null | `nil` | List of resource types to exclude from the backup. |
-| backup.includedNamespaceScopedResources | list, null | `nil` | List of namespace-scoped resource types to include in the backup. |
-| backup.excludedNamespaceScopedResources | list, null | `nil` | List of namespace-scoped resource types to exclude from the backup. |
-| backup.orderedResources | object, null | `nil` | Specifies the backup order of resources of specific Kind. The map key is the resource name and the value is a list of object names in the order they should be backed up. |
+| backup.includedNamespaces | tpl/list | `[ {{ include "application.namespace" $ }} ]` | List of namespaces to include objects from. |
+| backup.includedResources | list | `nil` | List of resource types to include in the backup. |
+| backup.excludedResources | list | `nil` | List of resource types to exclude from the backup. |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 
@@ -531,15 +497,6 @@ In order to use environment variable in deployment or cronjob, you will have to 
 
   **Note:** first key after `envFrom` is just used to uniquely identify different objects in `envFrom` block. Make sure to keep it unique and relevant.
 
-  To reference an **existing external ConfigMap** not managed by this chart, use `name` instead of `nameSuffix`:
-
-  ```yaml
-  envFrom:
-    external-configmap:
-      type: configmap
-      name: my-existing-configmap
-  ```
-
 - To get environment variable value from **Secret**
 
   Suppose we have secret created from application chart
@@ -579,15 +536,6 @@ In order to use environment variable in deployment or cronjob, you will have to 
   You can specify whether the secret is mandatory or optional for the pod to start with the `optional: true/false` value.
 
   **Note:** first key after `envFrom` is just used to uniquely identify different objects in `envFrom` block. Make sure to keep it unique and relevant.
-
-  To reference an **existing external Secret** not managed by this chart, use `name` instead of `nameSuffix`:
-
-  ```yaml
-  envFrom:
-    external-secret:
-      type: secret
-      name: my-existing-secret
-  ```
 
 ## Configuring probes
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,28 @@
 
 # Application
 
-Generic helm chart for applications which:
-
-- are stateless
-- creates only namespace scoped resources (e.g. it doesn't need CRB - Cluster Role Bindings)
-- don't need privileged containers
-- don't call the underlying Kubernetes API or use the underlying etcd as a database by defining custom resources
-- run either as deployment, job or cronjob
+Generic Helm chart for deploying stateless applications on Kubernetes. Supports Deployments, Jobs, and CronJobs along with common companion resources (Services, Ingress, RBAC, autoscaling, monitoring, certificates, and more).
 
 ## Installing the Chart
 
-To install the chart with the release name `my-application` in namespace `test`:
+### From the OCI registry
+
+```shell
+helm install my-application oci://ghcr.io/stakater/charts/application --namespace test
+# or, to install a specific version
+helm install my-application oci://ghcr.io/stakater/charts/application --version <version> --namespace test
+```
+
+### From the Helm repository (deprecated)
+
+> **Note:** The Helm repository is deprecated in favor of the OCI registry above.
 
 ```shell
 helm repo add stakater https://stakater.github.io/stakater-charts
 helm repo update
 helm install my-application stakater/application --namespace test
+# or, to install a specific version
+helm install my-application stakater/application --version <version> --namespace test
 ```
 
 ## Uninstall the Chart
@@ -28,67 +34,84 @@ To uninstall the chart:
 helm delete --namespace test my-application
 ```
 
+## CI scope
+
+The CI validates the chart against upstream Kubernetes using Helm and Kind. These jobs should be configured as required status checks in branch protection rules.
+
+Server-side API validation runs against Kubernetes v1.31, v1.33, and v1.35. The chart uses `Capabilities.APIVersions` fallbacks for legacy APIs (`batch/v1beta1`, `policy/v1beta1`, `autoscaling/v2beta2`), but these were removed from Kubernetes before v1.25. Only the stable API paths are exercised in CI.
+
+Kind validation uses a Kubernetes-compatible values profile that excludes non-standard resources (CRDs, OpenShift routes, etc.). Resources that depend on CRDs or platform-specific APIs are only validated as template rendering (no server-side check).
+
+## Values Schema
+
+The chart ships with a [JSON Schema](application/values.schema.json) for `values.yaml` validation. When using an editor that supports JSON Schema (e.g. VS Code with the YAML extension), you get autocompletion and inline validation out of the box.
+
+## Contributing
+
+Please refer to the [Contributing Guide](CONTRIBUTING.md) for details on how to set up your local environment and submit changes.
+
 ## Values
 
 ### Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| namespaceOverride | string | `""` | Override the namespace for all resources. |
-| componentOverride | string | `""` | Override the component label for all resources. |
-| partOfOverride | string | `""` | Override the partOf label for all resources. |
-| applicationName | string | `{{ .Chart.Name }}` | Application name. |
-| additionalLabels | tpl/object | `nil` | Additional labels for all resources. |
-| extraObjects | [list or object] of [tpl/object or tpl/string] | `nil` | Extra K8s manifests to deploy. Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are passed through tpl to render. |
+| namespaceOverride | string, null | `""` | Override the namespace for all resources. |
+| componentOverride | string, null | `""` | Override the component label for all resources. |
+| partOfOverride | string, null | `""` | Override the partOf label for all resources. |
+| applicationName | string, null | `{{ .Release.Name }}` | Application name. Used as a prefix for all resource names. |
+| additionalLabels | object, null | `nil` | Additional labels for all resources. Keys and values are evaluated as templates. |
+| extraObjects | list, object, null | `nil` | Extra K8s manifests to deploy. Can be of type list or object. If object, keys are ignored and only values are used. The used values can be defined as object or string and are evaluated as templates. |
 
 ### CronJob Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cronJob.enabled | bool | `false` | Deploy CronJob resources. |
-| cronJob.jobs | object | `nil` | Map of CronJob resources. Key will be used as a name suffix for the CronJob. Value is the CronJob configuration. See values for more details. |
+| cronJob.jobs | object, null | `nil` | Map of CronJob resources. Key will be used as a name suffix for the CronJob. Value is the CronJob configuration. See values for more details. |
 
 ### Job Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | job.enabled | bool | `false` | Deploy Job resources. |
-| job.jobs | object | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details. |
+| job.jobs | object, null | `nil` | Map of Job resources. Key will be used as a name suffix for the Job. Value is the Job configuration. See values for more details. |
 
 ### Deployment Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deployment.enabled | bool | `true` | Enable Deployment. |
-| deployment.additionalLabels | object | `nil` | Additional labels for Deployment. |
-| deployment.podLabels | object | `nil` | Additional pod labels which are used in Service's Label Selector. |
-| deployment.annotations | object | `nil` | Annotations for Deployment. |
-| deployment.additionalPodAnnotations | object | `nil` | Additional pod annotations. |
+| deployment.additionalLabels | object, null | `nil` | Additional labels for Deployment. |
+| deployment.podLabels | object, null | `nil` | Additional pod labels which are used in Service's Label Selector. |
+| deployment.annotations | object, null | `nil` | Annotations for Deployment. |
+| deployment.additionalPodAnnotations | object, null | `nil` | Additional pod annotations. |
 | deployment.strategy.type | string | `"RollingUpdate"` | Type of deployment strategy. |
 | deployment.reloadOnChange | bool | `true` | Reload deployment if attached Secret/ConfigMap changes. |
-| deployment.nodeSelector | object | `nil` | Select the node where the pods should be scheduled. |
-| deployment.hostAliases | list | `nil` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files. |
-| deployment.initContainers | object | `nil` | Add init containers to the pods. |
-| deployment.fluentdConfigAnnotations | object | `nil` | Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>. |
-| deployment.replicas | int | `nil` | Number of replicas. |
+| deployment.nodeSelector | object, null | `nil` | Select the node where the pods should be scheduled. |
+| deployment.hostAliases | list, null | `nil` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files. |
+| deployment.initContainers | object, null | `nil` | Add init containers to the pods. |
+| deployment.fluentdConfigAnnotations | object, null | `nil` | Configuration details for fluentdConfigurations. Only works for specific setup, see <https://medium.com/stakater/dynamic-log-processing-with-fluentd-konfigurator-and-slack-935a5de4eddb>. |
+| deployment.replicas | int, null | `nil` | Number of replicas. |
 | deployment.imagePullSecrets | list | `[]` | List of secrets to be used for pulling the images. |
-| deployment.envFrom | object | `nil` | Mount environment variables from ConfigMap or Secret to the pod. See the README "Consuming environment variable in application chart" section for more details. |
-| deployment.env | object | `nil` | Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details. |
-| deployment.volumes | object | `nil` | Volumes to be added to the pod. Key is the name of the volume. Value is the volume definition. |
-| deployment.volumeMounts | object | `nil` | Mount path for Volumes. Key is the name of the volume. Value is the volume mount definition. |
-| deployment.priorityClassName | string | `""` | Define the priority class for the pod. |
-| deployment.runtimeClassName | string | `""` | Set the runtimeClassName for the deployment's pods. |
-| deployment.tolerations | list | `nil` | Taint tolerations for the pods. |
-| deployment.affinity | object | `nil` | Affinity for the pods. |
-| deployment.topologySpreadConstraints | list | `nil` | Topology spread constraints for the pods. |
+| deployment.envFrom | object, null | `nil` | Mount environment variables from ConfigMap or Secret to the pod. Use `nameSuffix` for resources managed by this chart (name will be prefixed with application name), or `name` to reference an existing external ConfigMap or Secret not managed by this chart. See the README "Consuming environment variable in application chart" section for more details. |
+| deployment.env | object, null | `nil` | Environment variables to be added to the pod. See the README "Consuming environment variable in application chart" section for more details. |
+| deployment.volumes | object, null | `nil` | Volumes to be added to the pod. Key is the name of the volume. Value is the volume definition. |
+| deployment.volumeMounts | object, null | `nil` | Mount path for Volumes. Key is the name of the volume. Value is the volume mount definition. |
+| deployment.priorityClassName | string, null | `""` | Define the priority class for the pod. |
+| deployment.runtimeClassName | string, null | `""` | Set the runtimeClassName for the deployment's pods. |
+| deployment.tolerations | list, null | `nil` | Taint tolerations for the pods. |
+| deployment.affinity | object, null | `nil` | Affinity for the pods. |
+| deployment.topologySpreadConstraints | list, null | `nil` | Topology spread constraints for the pods. |
 | deployment.revisionHistoryLimit | int | `2` | Number of ReplicaSet revisions to retain. |
-| deployment.image.repository | tpl/string | `""` | Repository. |
-| deployment.image.tag | tpl/string | `""` | Tag. |
-| deployment.image.digest | tpl/string | `""` | Image digest. If resolved to a non-empty value, digest takes precedence on the tag. |
+| deployment.image.repository | tpl | `""` | Repository. |
+| deployment.image.tag | tpl | `""` | Tag. |
+| deployment.image.digest | tpl | `""` | Image digest. If resolved to a non-empty value, digest takes precedence on the tag. |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
-| deployment.dnsConfig | object | `nil` | DNS config for the pods. |
-| deployment.dnsPolicy | string | `""` | DNS Policy. |
-| deployment.startupProbe | object | See below | Startup probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.dnsConfig | object, null | `nil` | DNS config for the pods. |
+| deployment.dnsPolicy | string, null | `""` | DNS Policy. |
+| deployment.enableServiceLinks | bool | `true` | Enable Kubernetes service links. |
+| deployment.startupProbe | object, null | See below | Startup probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.startupProbe.enabled | bool | `false` | Enable Startup probe. |
 | deployment.startupProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.startupProbe.periodSeconds | int | `10` | Time between retries. |
@@ -98,7 +121,7 @@ helm delete --namespace test my-application
 | deployment.startupProbe.exec | object | `{}` | Exec probe. |
 | deployment.startupProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.startupProbe.grpc | object | `{}` | gRPC probe. |
-| deployment.readinessProbe | object | See below | Readiness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.readinessProbe | object, null | See below | Readiness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.readinessProbe.enabled | bool | `false` | Enable Readiness probe. |
 | deployment.readinessProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.readinessProbe.periodSeconds | int | `10` | Time between retries. |
@@ -108,7 +131,7 @@ helm delete --namespace test my-application
 | deployment.readinessProbe.exec | object | `{}` | Exec probe. |
 | deployment.readinessProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.readinessProbe.grpc | object | `{}` | gRPC probe. |
-| deployment.livenessProbe | object | See below | Liveness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
+| deployment.livenessProbe | object, null | See below | Liveness probe. Must specify either one of the following field when enabled: httpGet, exec, tcpSocket, grpc |
 | deployment.livenessProbe.enabled | bool | `false` | Enable Liveness probe. |
 | deployment.livenessProbe.failureThreshold | int | `30` | Number of retries before marking the pod as failed. |
 | deployment.livenessProbe.periodSeconds | int | `10` | Time between retries. |
@@ -119,60 +142,61 @@ helm delete --namespace test my-application
 | deployment.livenessProbe.tcpSocket | object | `{}` | TCP Socket probe. |
 | deployment.livenessProbe.grpc | object | `{}` | gRPC probe. |
 | deployment.resources | object | `{}` | Resource limits and requests for the pod. |
-| deployment.containerSecurityContext | object | `{"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
+| deployment.containerSecurityContext | object, null | `{"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security Context at Container Level. |
 | deployment.openshiftOAuthProxy.enabled | bool | `false` | Enable [OpenShift OAuth Proxy](https://github.com/openshift/oauth-proxy). |
 | deployment.openshiftOAuthProxy.port | int | `8080` | Port on which application is running inside container. |
 | deployment.openshiftOAuthProxy.secretName | string | `"openshift-oauth-proxy-tls"` | Secret name for the OAuth Proxy TLS certificate. |
-| deployment.openshiftOAuthProxy.image | string | `"openshift/oauth-proxy:latest"` | Image for the OAuth Proxy. |
+| deployment.openshiftOAuthProxy.image | string | `"quay.io/openshift/origin-oauth-proxy:latest@sha256:35967c4d152d7b21167e3ba0aae57e29d3a46a75a738329073ef2227cbc33bde"` | Image for the OAuth Proxy. |
 | deployment.openshiftOAuthProxy.disableTLSArg | bool | `false` | If disabled `--http-address=:8081` will be used instead of `--https-address=:8443`. It can be useful when an ingress is enabled for the application. |
-| deployment.securityContext | object | `nil` | Security Context for the pod. |
+| deployment.securityContext | object, null | `nil` | Security Context for the pod. |
 | deployment.command | list | `[]` | Command for the app container. |
 | deployment.args | list | `[]` | Args for the app container. |
-| deployment.automountServiceAccountToken | bool | `true` | Mount Service Account token. |
-| deployment.ports | list | `nil` | List of ports for the app container. |
-| deployment.hostNetwork | bool | `nil` | Host network connectivity. |
-| deployment.terminationGracePeriodSeconds | int | `nil` | Gracefull termination period. |
-| deployment.minReadySeconds | int | `nil` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing. |
+| deployment.automountServiceAccountToken | bool | `false` | Mount Service Account token. |
+| deployment.ports | list, null | `nil` | List of ports for the app container. |
+| deployment.hostNetwork | bool, null | `nil` | Host network connectivity. |
+| deployment.terminationGracePeriodSeconds | int, null | `nil` | Gracefull termination period. |
+| deployment.minReadySeconds | int, null | `nil` | Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing. |
 | deployment.lifecycle | object | `{}` | Lifecycle configuration for the pod. |
-| deployment.additionalContainers | list | `nil` | Additional containers besides init and app containers (without templating). |
+| deployment.additionalContainers | list, object, null | `nil` | Additional containers besides init and app containers (without templating). Supports both list and map formats. Map format makes overrides easier (e.g. ArgoCD). |
 | persistence.enabled | bool | `false` | Enable persistence. |
 | persistence.mountPVC | bool | `false` | Whether to mount the created PVC to the deployment. |
 | persistence.mountPath | string | `"/"` | If `persistence.mountPVC` is enabled, where to mount the volume in the containers. |
-| persistence.name | string | `{{ include "application.name" $ }}-data` | Name of the PVC. |
+| persistence.name | string, null | `{{ include "application.name" $ }}-data` | Name of the PVC. |
 | persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for volume. |
-| persistence.storageClass | string | `nil` | Storage class for volume. If defined, use that value If set to "-" or "", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner. |
-| persistence.additionalLabels | object | `nil` | Additional labels for persistent volume. |
-| persistence.annotations | object | `nil` | Annotations for persistent volume. |
+| persistence.storageClass | string, null | `nil` | Storage class for volume. If defined, use that value If set to "-" or "", disable dynamic provisioning If undefined or set to null (the default), no storageClass spec is   set, choosing the default provisioner. |
+| persistence.additionalLabels | object, null | `nil` | Additional labels for persistent volume. |
+| persistence.annotations | object, null | `nil` | Annotations for persistent volume. |
 | persistence.storageSize | string | `"8Gi"` | Size of the persistent volume. |
-| persistence.volumeMode | string | `""` | PVC Volume Mode. |
-| persistence.volumeName | string | `""` | Name of the volume. |
+| persistence.volumeMode | string, null | `""` | PVC Volume Mode. |
+| persistence.volumeName | string, null | `""` | Name of the volume. |
 
 ### Service Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | service.enabled | bool | `true` | Enable Service. |
-| service.additionalLabels | object | `nil` | Additional labels for service. |
-| service.annotations | object | `nil` | Annotations for service. |
+| service.additionalLabels | object, null | `nil` | Additional labels for service. |
+| service.annotations | object, null | `nil` | Annotations for service. |
 | service.ports | list | `[{"name":"http","port":8080,"protocol":"TCP","targetPort":8080}]` | Ports for applications service. |
+| service.ports[0].targetPort | int, string, null | `8080` | Target port on pods. Accepts port number or port name (IANA_SVC_NAME). |
 | service.type | string | `"ClusterIP"` | Type of service. |
-| service.clusterIP | string | `nil` | Fixed IP for a ClusterIP service. Set to `None` for an headless service |
-| service.loadBalancerClass | string | `nil` | LoadBalancer class name for LoadBalancer type services. |
+| service.clusterIP | string, null | `nil` | Fixed IP for a ClusterIP service. Set to `None` for an headless service |
+| service.loadBalancerClass | string, null | `nil` | LoadBalancer class name for LoadBalancer type services. |
 
 ### Ingress Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | ingress.enabled | bool | `false` | Enable Ingress. |
-| ingress.ingressClassName | string | `""` | Name of the ingress class. |
-| ingress.hosts[0].host | tpl/string | `"chart-example.local"` | Hostname. |
+| ingress.ingressClassName | string, null | `""` | Name of the ingress class. |
+| ingress.hosts[0].host | tpl | `"chart-example.local"` | Hostname. |
 | ingress.hosts[0].paths[0].path | string | `"/"` | Path. |
-| ingress.hosts[0].paths[0].pathType | string | `ImplementationSpecific` | Path type. |
-| ingress.hosts[0].paths[0].serviceName | string | `{{ include "application.name" $ }}` | Service name. |
-| ingress.hosts[0].paths[0].servicePort | string | `http` | Service port. |
-| ingress.additionalLabels | object | `nil` | Additional labels for ingress. |
-| ingress.annotations | object | `nil` | Annotations for ingress. |
-| ingress.tls | list | `nil` | TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret. |
+| ingress.hosts[0].paths[0].pathType | string, null | `ImplementationSpecific` | Path type. |
+| ingress.hosts[0].paths[0].serviceName | string, null | `{{ include "application.name" $ }}` | Service name. |
+| ingress.hosts[0].paths[0].servicePort | string, null | `http` | Service port. |
+| ingress.additionalLabels | object, null | `nil` | Additional labels for ingress. |
+| ingress.annotations | object, null | `nil` | Annotations for ingress. |
+| ingress.tls | list, null | `nil` | TLS configuration for ingress. Secrets must exist in the namespace. You may also configure Certificate resource to generate the secret. |
 
 ### VirtualService Parameters
 
@@ -192,52 +216,63 @@ helm delete --namespace test my-application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | httpRoute.enabled | bool | `false` | Enable HTTPRoute (Gateway API). |
-| httpRoute.parentRefs | tpl/list | `nil` | Parent references for the HTTPRoute. |
-| httpRoute.useDefaultGateways | string | `nil` | The default Gateway scope to use for this Route. If unset (the default) or set to None, the Route will not be attached to any default Gateway; if set, it will be attached to any default Gateway supporting the named scope, subject to the usual rules about which Routes a Gateway is allowed to claim. |
-| httpRoute.gatewayNamespace | string | `""` | Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute. |
-| httpRoute.hostnames | tpl/list | `nil` | Hostnames for the HTTPRoute. |
+| httpRoute.parentRefs | list, null | `nil` | Parent references for the HTTPRoute. Keys and values are evaluated as templates. |
+| httpRoute.useDefaultGateways | string, null | `nil` | The default Gateway scope to use for this Route. If unset (the default) or set to None, the Route will not be attached to any default Gateway; if set, it will be attached to any default Gateway supporting the named scope, subject to the usual rules about which Routes a Gateway is allowed to claim. |
+| httpRoute.gatewayNamespace | string, null | `""` | Namespace of the Gateway to attach this HTTPRoute to. If not set, the HTTPRoute will be attached to the Gateway in the same namespace as the HTTPRoute. |
+| httpRoute.hostnames | list, null | `nil` | Hostnames for the HTTPRoute. Values are evaluated as templates. |
 | httpRoute.additionalLabels | object | `{}` | Additional labels for HTTPRoute. |
 | httpRoute.annotations | object | `{}` | Annotations for HTTPRoute. |
-| httpRoute.rules | tpl/list | `[{"backendRefs":[{"name":"{{ include \"application.name\" $ }}","port":"{{ (first $.Values.service.ports).port | int }}"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. |
+| httpRoute.rules | list | `[{"backendRefs":[{"name":"{{ include \"application.name\" $ }}","port":"{{ (first $.Values.service.ports).port }}"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Rules for HTTPRoute. Keys and values are evaluated as templates. |
+| httpRoute.rules[0].backendRefs[0].port | int, tpl, null | `"{{ (first $.Values.service.ports).port }}"` | Port number or template expression for the backend service. Required when the referent is a Kubernetes Service (the default kind); optional for other kinds such as ServiceImport, where it is omitted from the manifest when unset or when a template expression renders empty. |
+
+### ListenerSet Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| listenerSet.enabled | bool | `false` | Enable ListenerSet (Gateway API). |
+| listenerSet.listeners | list, null | `nil` | Logical endpoints that are bound on this referenced parent Gateway's addresses. Keys and values are evaluated as templates. |
+| listenerSet.parentRef | object, null | `nil` | Parent Gateway reference for the ListenerSet. Keys and values are evaluated as templates. |
+| listenerSet.additionalLabels | object | `{}` | Additional labels for ListenerSet. |
+| listenerSet.annotations | object | `{}` | Annotations for ListenerSet. |
 
 ### Route Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | route.enabled | bool | `false` | Deploy a Route (OpenShift) resource. |
-| route.additionalLabels | object | `nil` | Additional labels for Route. |
-| route.annotations | object | `nil` | Annotations for Route. |
-| route.host | string | `nil` | Explicit host. If no host is added then openshift inserts the default hostname. |
-| route.path | string | `nil` | Path. |
-| route.port | object | `{"targetPort":"http"}` | Service port. |
+| route.additionalLabels | object, null | `nil` | Additional labels for Route. |
+| route.annotations | object, null | `nil` | Annotations for Route. |
+| route.host | string, null | `nil` | Explicit host. If no host is added then openshift inserts the default hostname. |
+| route.path | string, null | `nil` | Path. |
+| route.port | object, null | `{"targetPort":"http"}` | Service port. |
 | route.to.weight | int | `100` | Service weight. |
 | route.wildcardPolicy | string | `"None"` | Wildcard policy. |
 | route.tls.termination | string | `"edge"` | TLS termination strategy. |
 | route.tls.insecureEdgeTerminationPolicy | string | `"Redirect"` | TLS insecure termination policy. |
-| route.alternateBackends | list | `nil` | Alternate backend with it's weight. |
+| route.alternateBackends | object, null | `nil` | Alternate backend with it's weight. |
 
 ### SecretProviderClass Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | secretProviderClass.enabled | bool | `false` | Deploy a [Secrets Store CSI Driver SecretProviderClass](https://secrets-store-csi-driver.sigs.k8s.io/) resource. |
-| secretProviderClass.name | string | `""` | Name of the SecretProviderClass. Required if `secretProviderClass.enabled` is set to `true`. |
-| secretProviderClass.provider | string | `""` | Name of the provider. Required if `secretProviderClass.enabled` is set to `true`. |
-| secretProviderClass.vaultAddress | string | `""` | Vault Address. Required if `secretProviderClass.provider` is set to `vault`. |
-| secretProviderClass.roleName | tpl/string | `""` | Vault Role Name. Required if `secretProviderClass.provider` is set to `vault`. |
-| secretProviderClass.objects | list | `nil` | Objects definitions. |
-| secretProviderClass.secretObjects | list | `nil` | Objects mapping. |
+| secretProviderClass.name | string, null | `""` | Name of the SecretProviderClass. Required if `secretProviderClass.enabled` is set to `true`. |
+| secretProviderClass.provider | string, null | `""` | Name of the provider. Required if `secretProviderClass.enabled` is set to `true`. |
+| secretProviderClass.vaultAddress | string, null | `""` | Vault Address. Required if `secretProviderClass.provider` is set to `vault`. |
+| secretProviderClass.roleName | tpl | `""` | Vault Role Name. Required if `secretProviderClass.provider` is set to `vault`. |
+| secretProviderClass.objects | string, null | `nil` | Objects definitions. |
+| secretProviderClass.secretObjects | list, null | `nil` | Objects mapping. |
 
 ### ForecastleApp Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | forecastle.enabled | bool | `false` | Deploy a [ForecastleApp](https://github.com/stakater/Forecastle) resource. |
-| forecastle.additionalLabels | object | `nil` | Additional labels for ForecastleApp. |
+| forecastle.additionalLabels | object, null | `nil` | Additional labels for ForecastleApp. |
 | forecastle.icon | string | `"https://raw.githubusercontent.com/stakater/ForecastleIcons/master/stakater-big.png"` | Icon URL. |
-| forecastle.displayName | string | `""` | Application Name. Required if `forecastle.enabled` is set to `true`. |
-| forecastle.group | string | `{{ .Release.Namespace }}` | Application Group. |
-| forecastle.properties | object | `nil` | Custom properties. |
+| forecastle.displayName | string, null | `""` | Application Name. Required if `forecastle.enabled` is set to `true`. |
+| forecastle.group | string, null | `{{ .Release.Namespace }}` | Application Group. |
+| forecastle.properties | object, null | `nil` | Custom properties. |
 | forecastle.networkRestricted | bool | `false` | Is application network restricted?. |
 
 ### RBAC Parameters
@@ -245,46 +280,49 @@ helm delete --namespace test my-application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | rbac.enabled | bool | `true` | Enable RBAC. |
-| rbac.serviceAccount.enabled | bool | `false` | Deploy Service Account. |
-| rbac.serviceAccount.name | string | `{{ include "application.name" $ }}` | Service Account Name. |
-| rbac.serviceAccount.additionalLabels | object | `nil` | Additional labels for Service Account. |
-| rbac.serviceAccount.annotations | object | `nil` | Annotations for Service Account. |
-| rbac.roles | list | `nil` | Namespaced Roles. |
+| rbac.serviceAccount.create | bool | `false` | Specifies whether to create a dedicated service account. If set to `true`, a new service account will be created. |
+| rbac.serviceAccount.name | string, null | `""` | The name of the service account. Behavior based on its value and `rbac.serviceAccount.create`: If `rbac.serviceAccount.create` is `false` and `name` is empty, the default service account ("default") is used. If `rbac.serviceAccount.create` is `false` and `name` is set, the provided name is used. If `rbac.serviceAccount.create` is `true` and `name` is empty, a name is auto-generated using the fullname template. If `rbac.serviceAccount.create` is `true` and `name` is set, the provided name is used for creation. |
+| rbac.serviceAccount.additionalLabels | object, null | `nil` | Additional labels for Service Account. If `rbac.serviceAccount.create` is set to true, these labels are appended to the service account. |
+| rbac.serviceAccount.annotations | object, null | `nil` | Annotations for Service Account. If `rbac.serviceAccount.create` is set to true, these annotations are appended to the service account. |
+| rbac.roles | list, null | `nil` | Role definitions scoped to a single namespace. |
+| rbac.clusterRoles | list, null | `nil` | ClusterRole definitions with cluster-wide permissions. |
+| rbac.additionalLabels | object, null | `nil` | Additional labels for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
+| rbac.annotations | object, null | `nil` | Annotations for the Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources. |
 
 ### ConfigMap Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | configMap.enabled | bool | `false` | Deploy additional ConfigMaps. |
-| configMap.additionalLabels | object | `nil` | Additional labels for ConfigMaps. |
-| configMap.annotations | object | `nil` | Annotations for ConfigMaps. |
-| configMap.files | object | `nil` | List of ConfigMap entries. Key will be used as a name suffix for the ConfigMap. Value is the ConfigMap content. |
+| configMap.additionalLabels | object, null | `nil` | Additional labels for ConfigMaps. |
+| configMap.annotations | object, null | `nil` | Annotations for ConfigMaps. |
+| configMap.files | object, null | `nil` | List of ConfigMap entries. Key will be used as a name suffix for the ConfigMap. Value is the ConfigMap content. |
 
 ### SealedSecret Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | sealedSecret.enabled | bool | `false` | Deploy [SealedSecret](https://github.com/bitnami-labs/sealed-secrets) resources. |
-| sealedSecret.additionalLabels | object | `nil` | Additional labels for SealedSecret. |
-| sealedSecret.annotations | object | `nil` | Annotations for SealedSecret. |
-| sealedSecret.files | object | `nil` | List of SealedSecret entries. Key will be used as a name suffix for the SealedSecret. Value is the SealedSecret content. |
+| sealedSecret.additionalLabels | object, null | `nil` | Additional labels for SealedSecret. |
+| sealedSecret.annotations | object, null | `nil` | Annotations for SealedSecret. |
+| sealedSecret.files | object, null | `nil` | List of SealedSecret entries. Key will be used as a name suffix for the SealedSecret. Value is the SealedSecret content. |
 
 ### Secret Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | secret.enabled | bool | `false` | Deploy additional Secret resources. |
-| secret.additionalLabels | object | `nil` | Additional labels for Secret. |
-| secret.annotations | object | `nil` | Annotations for Secret. |
-| secret.files | object | `nil` | List of Secrets entries. Key will be used as a name suffix for the Secret. There a three allowed modes: - `data`: Data is base64 encoded by the chart - `encodedData`: Use raw values (already base64ed) inside the data map - `stringData`: Use raw values inside the stringData map |
+| secret.additionalLabels | object, null | `nil` | Additional labels for Secret. |
+| secret.annotations | object, null | `nil` | Annotations for Secret. |
+| secret.files | object, null | `nil` | List of Secrets entries. Key will be used as a name suffix for the Secret. There a three allowed modes: - `data`: Data is base64 encoded by the chart - `encodedData`: Use raw values (already base64ed) inside the data map - `stringData`: Use raw values inside the stringData map |
 
 ### ServiceMonitor Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | serviceMonitor.enabled | bool | `false` | Deploy a ServiceMonitor (Prometheus Operator) resource. |
-| serviceMonitor.additionalLabels | object | `nil` | Additional labels for ServiceMonitor. |
-| serviceMonitor.annotations | object | `nil` | Annotations for ServiceMonitor. |
+| serviceMonitor.additionalLabels | object, null | `nil` | Additional labels for ServiceMonitor. |
+| serviceMonitor.annotations | object, null | `nil` | Annotations for ServiceMonitor. |
 | serviceMonitor.endpoints | list | `[{"interval":"5s","path":"/actuator/prometheus","port":"http"}]` | Service endpoints from which prometheus will scrape data. |
 
 ### Autoscaling - Horizontal Pod Autoscaling Parameters
@@ -292,8 +330,8 @@ helm delete --namespace test my-application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaling. |
-| autoscaling.additionalLabels | object | `nil` | Additional labels for HPA. |
-| autoscaling.annotations | object | `nil` | Annotations for HPA. |
+| autoscaling.additionalLabels | object, null | `nil` | Additional labels for HPA. |
+| autoscaling.annotations | object, null | `nil` | Annotations for HPA. |
 | autoscaling.minReplicas | int | `1` | Minimum number of replicas. |
 | autoscaling.maxReplicas | int | `10` | Maximum number of replicas. |
 | autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":60,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":60,"type":"Utilization"}},"type":"Resource"}]` | Metrics used for autoscaling. |
@@ -303,40 +341,40 @@ helm delete --namespace test my-application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaling. |
-| vpa.additionalLabels | object | `nil` | Additional labels for VPA. |
-| vpa.annotations | object | `nil` | Annotations for VPA. |
+| vpa.additionalLabels | object, null | `nil` | Additional labels for VPA. |
+| vpa.annotations | object, null | `nil` | Annotations for VPA. |
 | vpa.containerPolicies | list | `[]` | Container policies for individual containers. |
-| vpa.updatePolicy | object | `{"updateMode":"Auto"}` | Update policy. |
+| vpa.updatePolicy | object, null | `{"updateMode":"Auto"}` | Update policy. |
 
 ### EndpointMonitor Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | endpointMonitor.enabled | bool | `false` | Deploy an [IMC EndpointMonitor](https://github.com/stakater/IngressMonitorController) resource. |
-| endpointMonitor.additionalLabels | object | `nil` | Additional labels for EndpointMonitor. |
-| endpointMonitor.annotations | object | `nil` | Annotations for EndpointMonitor. |
+| endpointMonitor.additionalLabels | object, null | `nil` | Additional labels for EndpointMonitor. |
+| endpointMonitor.annotations | object, null | `nil` | Annotations for EndpointMonitor. |
 
 ### cert-manager Certificate Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | certificate.enabled | bool | `false` | Deploy a [cert-manager Certificate](https://cert-manager.io) resource. |
-| certificate.additionalLabels | object | `nil` | Additional labels for Certificate. |
-| certificate.annotations | object | `nil` | Annotations for Certificate. |
-| certificate.secretName | tpl/string | `"tls-cert"` | Name of the secret resource that will be automatically created and managed by this Certificate resource. |
+| certificate.additionalLabels | object, null | `nil` | Additional labels for Certificate. |
+| certificate.annotations | object, null | `nil` | Annotations for Certificate. |
+| certificate.secretName | tpl | `"tls-cert"` | Name of the secret resource that will be automatically created and managed by this Certificate resource. |
 | certificate.duration | string | `"8760h0m0s"` | The requested "duration" (i.e. lifetime) of the Certificate. |
 | certificate.renewBefore | string | `"720h0m0s"` | The amount of time before the currently issued certificate's notAfter time that cert-manager will begin to attempt to renew the certificate. |
-| certificate.subject | tpl/object | `nil` | Full X509 name specification for certificate. |
-| certificate.commonName | tpl/string | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
+| certificate.subject | object, null | `nil` | Full X509 name specification for certificate. Keys and values are evaluated as templates. |
+| certificate.commonName | tpl, null | `nil` | Common name as specified on the DER encoded CSR. This field is not recommended in cases when this certificate is an end-entity certificate. More information can be found in the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/#:~:text=%23%20Avoid%20using%20commonName,%3A%20example.com). |
 | certificate.keyAlgorithm | string | `"RSA"` | Private key algorithm of the corresponding private key for this certificate. |
 | certificate.keyEncoding | string | `"PKCS1"` | Private key cryptography standards (PKCS) for this certificate's private key to be encoded in. |
 | certificate.keySize | int | `2048` | Key bit size of the corresponding private key for this certificate. |
 | certificate.isCA | bool | `false` | Mark this Certificate as valid for certificate signing. |
-| certificate.usages | list | `nil` | Set of x509 usages that are requested for the certificate. |
-| certificate.dnsNames | tpl/list | `nil` | List of DNS subjectAltNames to be set on the certificate. |
-| certificate.ipAddresses | list | `nil` | List of IP address subjectAltNames to be set on the certificate. |
-| certificate.uriSANs | list | `nil` | List of URI subjectAltNames to be set on the certificate. |
-| certificate.emailSANs | list | `nil` | List of email subjectAltNames to be set on the Certificate. |
+| certificate.usages | list, null | `nil` | Set of x509 usages that are requested for the certificate. |
+| certificate.dnsNames | list, null | `nil` | List of DNS subjectAltNames to be set on the certificate. Keys and values are evaluated as templates. |
+| certificate.ipAddresses | list, null | `nil` | List of IP address subjectAltNames to be set on the certificate. |
+| certificate.uriSANs | list, null | `nil` | List of URI subjectAltNames to be set on the certificate. |
+| certificate.emailSANs | list, null | `nil` | List of email subjectAltNames to be set on the Certificate. |
 | certificate.privateKey.enabled | bool | `false` | Enable Private Key for the certificate. |
 | certificate.privateKey.rotationPolicy | string | `"Always"` | Denotes how private keys should be generated or sourced when a certificate is being issued. |
 | certificate.issuerRef.name | string | `"ca-issuer"` | Reference to the issuer for this certificate. |
@@ -347,7 +385,7 @@ helm delete --namespace test my-application
 | certificate.keystores.pkcs12.key | string | `"test_key"` | Key of the entry in the Secret resource's data field to be used. |
 | certificate.keystores.pkcs12.name | string | `"test-creds"` | Name of the Secret resource being referred to. |
 | certificate.keystores.jks.create | bool | `false` | Enables jks keystore creation for the Certificate. JKS configures options for storing a JKS keystore in the spec.secretName Secret resource. |
-| certificate.keystores.jks.key | tpl/string | `"test_key"` | Key of the entry in the Secret resource's data field to be used. |
+| certificate.keystores.jks.key | tpl | `"test_key"` | Key of the entry in the Secret resource's data field to be used. |
 | certificate.keystores.jks.name | string | `"test-creds"` | Name of the Secret resource being referred to. |
 
 ### AlertmanagerConfig Parameters
@@ -355,9 +393,9 @@ helm delete --namespace test my-application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | alertmanagerConfig.enabled | bool | `false` | Deploy an AlertmanagerConfig (Prometheus Operator) resource. |
-| alertmanagerConfig.selectionLabels | object | `{"alertmanagerConfig":"workload"}` | Labels to be picked up by Alertmanager to add it to base config. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html](OpenShift's AlermanagerConfig documentation) under .spec.alertmanagerConfigSelector. |
-| alertmanagerConfig.spec | object | `{"inhibitRules":[],"receivers":[],"route":null}` | AlertmanagerConfig spec. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html](OpenShift's AlermanagerConfig documentation). |
-| alertmanagerConfig.spec.route | object | `nil` | Route definition for alerts matching the resource’s namespace. It will be added to the generated Alertmanager configuration as a first-level route. |
+| alertmanagerConfig.selectionLabels | object, null | `{"alertmanagerConfig":"workload"}` | Labels to be picked up by Alertmanager to add it to base config. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html](OpenShift's AlermanagerConfig documentation) under .spec.alertmanagerConfigSelector. |
+| alertmanagerConfig.spec | object, null | `{"inhibitRules":[],"receivers":[],"route":null}` | AlertmanagerConfig spec. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html](OpenShift's AlermanagerConfig documentation). |
+| alertmanagerConfig.spec.route | object, null | `nil` | Route definition for alerts matching the resource’s namespace. It will be added to the generated Alertmanager configuration as a first-level route. |
 | alertmanagerConfig.spec.receivers | list | `[]` | List of receivers. |
 | alertmanagerConfig.spec.inhibitRules | list | `[]` | Inhibition rules that allows to mute alerts when other alerts are already firing. |
 
@@ -366,7 +404,7 @@ helm delete --namespace test my-application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prometheusRule.enabled | bool | `false` | Deploy a PrometheusRule (Prometheus Operator) resource. |
-| prometheusRule.additionalLabels | object | `nil` | Additional labels for PrometheusRule. |
+| prometheusRule.additionalLabels | object, null | `nil` | Additional labels for PrometheusRule. |
 | prometheusRule.groups | list | `[]` | Groups with alerting rules. Read more about it at [https://docs.openshift.com/container-platform/4.7/rest_api/monitoring_apis/prometheusrule-monitoring-coreos-com-v1.html](OpenShift's PrometheusRule documentation). |
 
 ### ExternalSecret Parameters
@@ -374,56 +412,65 @@ helm delete --namespace test my-application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | externalSecret.enabled | bool | `false` | Deploy [ExternalSecret](https://external-secrets.io/latest/) resources. |
-| externalSecret.additionalLabels | object | `nil` | Additional labels for ExternalSecret. |
-| externalSecret.annotations | object | `nil` | Annotations for ExternalSecret. |
-| externalSecret.secretStore | object | `{"kind":"SecretStore","name":"tenant-vault-secret-store"}` | Default values for the SecretStore. Can be overriden per ExternalSecret in the `externalSecret.files` object. |
+| externalSecret.additionalLabels | object, null | `nil` | Additional labels for ExternalSecret. |
+| externalSecret.annotations | object, null | `nil` | Annotations for ExternalSecret. |
+| externalSecret.secretStore | object, null | `{"kind":"SecretStore","name":"tenant-vault-secret-store"}` | Default values for the SecretStore. Can be overriden per ExternalSecret in the `externalSecret.files` object. |
 | externalSecret.secretStore.name | string | `"tenant-vault-secret-store"` | Name of the SecretStore to use. |
 | externalSecret.secretStore.kind | string | `"SecretStore"` | Kind of the SecretStore being refered to. |
 | externalSecret.refreshInterval | string | `"1m"` | RefreshInterval is the amount of time before the values are read again from the SecretStore provider. |
-| externalSecret.files | object | `nil` | List of ExternalSecret entries. Key will be used as a name suffix for the ExternalSecret. There a two allowed modes: - `data`: Data defines the connection between the Kubernetes Secret keys and the Provider data - `dataFrom`: Used to fetch all properties from the Provider key |
+| externalSecret.files | object, null | `nil` | List of ExternalSecret entries. Key will be used as a name suffix for the ExternalSecret. There a two allowed modes: - `data`: Data defines the connection between the Kubernetes Secret keys and the Provider data - `dataFrom`: Used to fetch all properties from the Provider key |
 
 ### NetworkPolicy Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | networkPolicy.enabled | bool | `false` | Enable Network Policy. |
-| networkPolicy.additionalLabels | object | `nil` | Additional labels for Network Policy. |
-| networkPolicy.annotations | object | `nil` | Annotations for Network Policy. |
-| networkPolicy.ingress | list | `nil` | Ingress rules for Network Policy. |
-| networkPolicy.egress | list | `nil` | Egress rules for Network Policy. |
+| networkPolicy.additionalLabels | object, null | `nil` | Additional labels for Network Policy. |
+| networkPolicy.annotations | object, null | `nil` | Annotations for Network Policy. |
+| networkPolicy.ingress | list, null | `nil` | Ingress rules for Network Policy. |
+| networkPolicy.egress | list, null | `nil` | Egress rules for Network Policy. |
 
 ### PodDisruptionBudget Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | pdb.enabled | bool | `false` | Enable Pod Disruption Budget. |
-| pdb.minAvailable | int | `1` | Minimum number of pods that must be available after eviction. |
-| pdb.maxUnavailable | int | `nil` | Maximum number of unavailable pods during voluntary disruptions. |
+| pdb.minAvailable | int, string, null | `1` | Minimum number of pods that must be available after eviction. Accepts both integers and percentage strings (e.g. "25%"). |
+| pdb.maxUnavailable | int, string, null | `nil` | Maximum number of unavailable pods during voluntary disruptions. Accepts both integers and percentage strings (e.g. "25%"). |
 
 ### GrafanaDashboard Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | grafanaDashboard.enabled | bool | `false` | Deploy [GrafanaDashboard](https://github.com/grafana/grafana-operator) resources. |
-| grafanaDashboard.additionalLabels | object | `nil` | Additional labels for GrafanaDashboard. |
-| grafanaDashboard.annotations | object | `nil` | Annotations for GrafanaDashboard. |
-| grafanaDashboard.contents | object | `nil` | List of GrafanaDashboard entries. Key will be used as a name suffix for the GrafanaDashboard. Value is the GrafanaDashboard content. According to GrafanaDashboard behavior, `url` field takes precedence on the `json` field. |
+| grafanaDashboard.additionalLabels | object, null | `nil` | Additional labels for GrafanaDashboard. |
+| grafanaDashboard.annotations | object, null | `nil` | Annotations for GrafanaDashboard. |
+| grafanaDashboard.contents | object, null | `nil` | List of GrafanaDashboard entries. Key will be used as a name suffix for the GrafanaDashboard. Value is the GrafanaDashboard content. According to GrafanaDashboard behavior, `url` field takes precedence on the `json` field. |
 
 ### Backup Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backup.enabled | bool | `false` | Deploy a [Velero/OADP Backup](https://velero.io/docs/main/api-types/backup/) resource. |
-| backup.namespace | string | `{{ .Release.Namespace }}` | Namespace for Backup. |
-| backup.additionalLabels | object | `nil` | Additional labels for Backup. |
-| backup.annotations | object | `nil` | Annotations for Backup. |
-| backup.defaultVolumesToRestic | bool | `true` | Whether to use Restic to take snapshots of all pod volumes by default. |
+| backup.namespace | string, null | `{{ .Release.Namespace }}` | Namespace for Backup. |
+| backup.additionalLabels | object, null | `nil` | Additional labels for Backup. |
+| backup.annotations | object, null | `nil` | Annotations for Backup. |
+| backup.defaultVolumesToFsBackup | bool | `true` | Whether to use filesystem backup to take snapshots of all pod volumes by default. |
+| backup.defaultVolumesToRestic | bool, null | `nil` | Whether to use Restic to take snapshots of all pod volumes by default. Deprecated: Use `defaultVolumesToFsBackup` instead. |
 | backup.snapshotVolumes | bool | `true` | Whether to take snapshots of persistent volumes as part of the backup. |
-| backup.storageLocation | string | `nil` | Name of the backup storage location where the backup should be stored. |
+| backup.snapshotMoveData | bool, null | `nil` | Whether to move the data of the snapshot after it's taken. |
+| backup.csiSnapshotTimeout | string, null | `nil` | Time to wait for CSI VolumeSnapshot status to turn ReadyToUse during creation (e.g., "10m"). |
+| backup.datamover | string, null | `nil` | Data mover to be used by the backup. If empty or "velero", the built-in data mover will be used. |
+| backup.itemOperationTimeout | string, null | `nil` | Time to wait for asynchronous BackupItemAction operations (e.g., "1h"). |
+| backup.storageLocation | string, null | `nil` | Name of the backup storage location where the backup should be stored. |
 | backup.ttl | string | `"1h0m0s"` | How long the Backup should be retained for. |
-| backup.includedNamespaces | tpl/list | `[ {{ include "application.namespace" $ }} ]` | List of namespaces to include objects from. |
-| backup.includedResources | list | `nil` | List of resource types to include in the backup. |
-| backup.excludedResources | list | `nil` | List of resource types to exclude from the backup. |
+| backup.volumeSnapshotLocations | list, null | `nil` | Names of VolumeSnapshotLocations associated with this backup. |
+| backup.includedNamespaces | list, null | `[ {{ include "application.namespace" $ }} ]` | List of namespaces to include objects from. Values are evaluated as templates. |
+| backup.includedResources | list, null | `nil` | List of resource types to include in the backup. |
+| backup.excludedResources | list, null | `nil` | List of resource types to exclude from the backup. |
+| backup.includedNamespaceScopedResources | list, null | `nil` | List of namespace-scoped resource types to include in the backup. |
+| backup.excludedNamespaceScopedResources | list, null | `nil` | List of namespace-scoped resource types to exclude from the backup. |
+| backup.orderedResources | object, null | `nil` | Specifies the backup order of resources of specific Kind. The map key is the resource name and the value is a list of object names in the order they should be backed up. |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 
@@ -497,6 +544,15 @@ In order to use environment variable in deployment or cronjob, you will have to 
 
   **Note:** first key after `envFrom` is just used to uniquely identify different objects in `envFrom` block. Make sure to keep it unique and relevant.
 
+  To reference an **existing external ConfigMap** not managed by this chart, use `name` instead of `nameSuffix`:
+
+  ```yaml
+  envFrom:
+    external-configmap:
+      type: configmap
+      name: my-existing-configmap
+  ```
+
 - To get environment variable value from **Secret**
 
   Suppose we have secret created from application chart
@@ -536,6 +592,15 @@ In order to use environment variable in deployment or cronjob, you will have to 
   You can specify whether the secret is mandatory or optional for the pod to start with the `optional: true/false` value.
 
   **Note:** first key after `envFrom` is just used to uniquely identify different objects in `envFrom` block. Make sure to keep it unique and relevant.
+
+  To reference an **existing external Secret** not managed by this chart, use `name` instead of `nameSuffix`:
+
+  ```yaml
+  envFrom:
+    external-secret:
+      type: secret
+      name: my-existing-secret
+  ```
 
 ## Configuring probes
 

--- a/application/templates/virtualservice.yaml
+++ b/application/templates/virtualservice.yaml
@@ -1,0 +1,49 @@
+{{- $root := . -}}
+{{- if (.Values.virtualService).enabled -}}
+{{- $routes := .Values.virtualService.routes | default (dict "default" (omit .Values.virtualService "enabled" "routes")) -}}
+{{- range $name, $vs := $routes }}
+---
+{{- if $root.Capabilities.APIVersions.Has "networking.istio.io/v1/VirtualService" }}
+apiVersion: networking.istio.io/v1
+{{- else }}
+apiVersion: networking.istio.io/v1beta1
+{{- end }}
+kind: VirtualService
+metadata:
+  name: {{ template "application.name" $root }}{{ if ne $name "default" }}-{{ $name }}{{ end }}
+  namespace: {{ include "application.namespace" $root }}
+  labels:
+    {{- include "application.labels" $root | nindent 4 }}
+spec:
+  {{- if $vs.hosts }}
+  hosts:
+  {{- range $vs.hosts }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if $vs.gateways }}
+  gateways:
+  {{- range $vs.gateways }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if $vs.exportTo }}
+  exportTo:
+  {{- range $vs.exportTo }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if $vs.http }}
+  http:
+  {{- toYaml $vs.http | nindent 2 }}
+  {{- end }}
+  {{- if $vs.tls }}
+  tls:
+  {{- toYaml $vs.tls | nindent 2 }}
+  {{- end }}
+  {{- if $vs.tcp }}
+  tcp:
+  {{- toYaml $vs.tcp | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/application/tests/virtualservice_test.yaml
+++ b/application/tests/virtualservice_test.yaml
@@ -1,0 +1,259 @@
+suite: IstioVirtualService
+
+templates:
+  - virtualservice.yaml
+
+tests:
+  - it: does not render when virtualService is not enabled
+    set:
+      virtualService:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a single VirtualService when enabled with no routes map
+    set:
+      applicationName: my-app
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+        gateways:
+          - istio-system/istio-gateway
+        http:
+          - match:
+              - uri:
+                  prefix: /
+            route:
+              - destination:
+                  host: my-app
+                  port:
+                    number: 80
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VirtualService
+      - equal:
+          path: metadata.name
+          value: my-app
+      - equal:
+          path: spec.hosts[0]
+          value: my-app.example.com
+      - equal:
+          path: spec.gateways[0]
+          value: istio-system/istio-gateway
+
+  - it: uses networking.istio.io/v1 when the API version is available
+    set:
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1/VirtualService
+    asserts:
+      - isAPIVersion:
+          of: networking.istio.io/v1
+
+  - it: falls back to networking.istio.io/v1beta1 when v1 is unavailable
+    set:
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+    capabilities:
+      apiVersions:
+        - apps/v1
+    asserts:
+      - isAPIVersion:
+          of: networking.istio.io/v1beta1
+
+  - it: renders http routes as pass-through YAML
+    set:
+      applicationName: my-app
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+        http:
+          - match:
+              - uri:
+                  prefix: /api
+            route:
+              - destination:
+                  host: my-app
+                  port:
+                    number: 8080
+    asserts:
+      - equal:
+          path: spec.http[0].match[0].uri.prefix
+          value: /api
+      - equal:
+          path: spec.http[0].route[0].destination.port.number
+          value: 8080
+
+  - it: renders exportTo when specified
+    set:
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+        exportTo:
+          - "."
+          - istio-system
+    asserts:
+      - equal:
+          path: spec.exportTo[0]
+          value: "."
+      - equal:
+          path: spec.exportTo[1]
+          value: istio-system
+
+  - it: omits spec.gateways when not provided
+    set:
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+    asserts:
+      - isNull:
+          path: spec.gateways
+
+  - it: omits spec.http when not provided
+    set:
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+    asserts:
+      - isNull:
+          path: spec.http
+
+  - it: renders multiple VirtualServices from the routes map
+    set:
+      applicationName: my-app
+      virtualService:
+        enabled: true
+        routes:
+          web:
+            hosts:
+              - web.example.com
+            gateways:
+              - istio-system/istio-gateway
+            http:
+              - route:
+                  - destination:
+                      host: my-app
+                      port:
+                        number: 80
+          grpc:
+            hosts:
+              - grpc.example.com
+            gateways:
+              - istio-system/istio-gateway
+            http:
+              - route:
+                  - destination:
+                      host: my-app
+                      port:
+                        number: 9090
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: appends the route key as a name suffix for non-default routes
+    set:
+      applicationName: my-app
+      virtualService:
+        enabled: true
+        routes:
+          api:
+            hosts:
+              - api.example.com
+            http:
+              - route:
+                  - destination:
+                      host: my-app
+                      port:
+                        number: 8080
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-app-api
+
+  - it: does not append a suffix for the default route key
+    set:
+      applicationName: my-app
+      virtualService:
+        enabled: true
+        routes:
+          default:
+            hosts:
+              - my-app.example.com
+            http:
+              - route:
+                  - destination:
+                      host: my-app
+                      port:
+                        number: 80
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-app
+
+  - it: renders tls routes when specified
+    set:
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+        tls:
+          - match:
+              - port: 443
+                sniHosts:
+                  - my-app.example.com
+            route:
+              - destination:
+                  host: my-app
+                  port:
+                    number: 443
+    asserts:
+      - equal:
+          path: spec.tls[0].match[0].port
+          value: 443
+
+  - it: renders tcp routes when specified
+    set:
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+        tcp:
+          - match:
+              - port: 5432
+            route:
+              - destination:
+                  host: my-app
+                  port:
+                    number: 5432
+    asserts:
+      - equal:
+          path: spec.tcp[0].match[0].port
+          value: 5432
+
+  - it: includes standard labels on the VirtualService
+    set:
+      applicationName: my-app
+      virtualService:
+        enabled: true
+        hosts:
+          - my-app.example.com
+    asserts:
+      - isNotNull:
+          path: metadata.labels["app.kubernetes.io/name"]
+

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -2786,6 +2786,113 @@
       "required": [],
       "title": "vpa",
       "type": "object"
+    },
+    "virtualService": {
+      "description": "Deploy an Istio VirtualService resource. Requires Istio to be installed (networking.istio.io CRDs). Uses networking.istio.io/v1 if available, falls back to v1beta1.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Deploy an Istio VirtualService resource.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "hosts": {
+          "default": [],
+          "description": "Hostnames this VirtualService applies to. Can be a DNS name, wildcard (*.example.com), or short name resolved relative to the VS namespace.",
+          "items": {
+            "type": "string"
+          },
+          "title": "hosts",
+          "type": "array"
+        },
+        "gateways": {
+          "default": [],
+          "description": "Gateways this VirtualService is bound to. Use <namespace>/<name> format. Omit to apply rules to mesh-internal sidecar traffic only.",
+          "items": {
+            "type": "string"
+          },
+          "title": "gateways",
+          "type": "array"
+        },
+        "exportTo": {
+          "default": [],
+          "description": "Namespaces this VirtualService is exported to. '.' = same namespace only, '*' = all namespaces (default when omitted).",
+          "items": {
+            "type": "string"
+          },
+          "title": "exportTo",
+          "type": "array"
+        },
+        "http": {
+          "default": [],
+          "description": "Ordered HTTP route rules. First matching rule wins. Supports the full Istio HTTPRoute spec: match, route, rewrite, redirect, retries, timeout, fault, corsPolicy, headers, mirror, directResponse, delegate.",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "http",
+          "type": "array"
+        },
+        "tls": {
+          "default": [],
+          "description": "Ordered TLS route rules for non-terminated TLS/HTTPS traffic (SNI-based routing).",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "tls",
+          "type": "array"
+        },
+        "tcp": {
+          "default": [],
+          "description": "Ordered TCP route rules for opaque TCP traffic (non-HTTP, non-TLS ports).",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "tcp",
+          "type": "array"
+        },
+        "routes": {
+          "default": {},
+          "description": "Multiple VirtualServices — use when you need more than one VS for this app. Each key produces a separate VS named <app>-<key>. When routes is set, the top-level hosts/gateways/http/tls/tcp fields are ignored.",
+          "additionalProperties": {
+            "properties": {
+              "hosts": {
+                "items": { "type": "string" },
+                "type": "array"
+              },
+              "gateways": {
+                "items": { "type": "string" },
+                "type": "array"
+              },
+              "exportTo": {
+                "items": { "type": "string" },
+                "type": "array"
+              },
+              "http": {
+                "items": { "type": "object", "required": [] },
+                "type": "array"
+              },
+              "tls": {
+                "items": { "type": "object", "required": [] },
+                "type": "array"
+              },
+              "tcp": {
+                "items": { "type": "object", "required": [] },
+                "type": "array"
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "title": "routes",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "virtualService",
+      "type": "object"
     }
   },
   "required": [],

--- a/application/values.schema.json
+++ b/application/values.schema.json
@@ -2730,6 +2730,80 @@
       "title": "serviceMonitor",
       "type": "object"
     },
+    "virtualService": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Deploy an Istio VirtualService resource. Requires Istio to be installed in the cluster (networking.istio.io CRDs). Uses networking.istio.io/v1 if available, falls back to v1beta1.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "exportTo": {
+          "description": "Namespaces this VirtualService is exported to. \".\" = same namespace only, \"*\" = all namespaces (default when omitted).",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "exportTo",
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "gateways": {
+          "description": "Gateways this VirtualService is bound to. Use \u003cnamespace\u003e/\u003cname\u003e format (e.g. istio-system/istio-gateway). Omit to apply rules to mesh-internal sidecar traffic only (mesh gateway).",
+          "items": {
+            "required": []
+          },
+          "title": "gateways",
+          "type": "array"
+        },
+        "hosts": {
+          "description": "Hostnames this VirtualService applies to. Can be a DNS name, wildcard (*.example.com), or short name (resolved relative to the VS namespace).",
+          "items": {
+            "required": []
+          },
+          "title": "hosts",
+          "type": "array"
+        },
+        "http": {
+          "description": "Ordered HTTP route rules. First matching rule wins. Supports the full Istio HTTPRoute spec: match, route, rewrite, redirect, retries, timeout, fault, corsPolicy, headers, mirror, directResponse, delegate.",
+          "items": {
+            "required": []
+          },
+          "title": "http",
+          "type": "array"
+        },
+        "routes": {
+          "description": "Multiple VirtualServices — use when you need more than one VS for this app (e.g. external gateway + internal mesh-only rules). Each key produces a separate VS named \u003capp\u003e-\u003ckey\u003e. Each entry supports the same fields as the top-level (hosts, gateways, exportTo, http, tls, tcp). When routes is set, the top-level hosts/gateways/http/tls/tcp fields are ignored.",
+          "required": [],
+          "title": "routes",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "tcp": {
+          "description": "Ordered TCP route rules for opaque TCP traffic (non-HTTP, non-TLS ports).",
+          "items": {
+            "required": []
+          },
+          "title": "tcp",
+          "type": "array"
+        },
+        "tls": {
+          "description": "Ordered TLS route rules for non-terminated TLS/HTTPS (SNI-based routing).",
+          "items": {
+            "required": []
+          },
+          "title": "tls",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "virtualService",
+      "type": "object"
+    },
     "vpa": {
       "properties": {
         "additionalLabels": {
@@ -2785,113 +2859,6 @@
       },
       "required": [],
       "title": "vpa",
-      "type": "object"
-    },
-    "virtualService": {
-      "description": "Deploy an Istio VirtualService resource. Requires Istio to be installed (networking.istio.io CRDs). Uses networking.istio.io/v1 if available, falls back to v1beta1.",
-      "properties": {
-        "enabled": {
-          "default": false,
-          "description": "Deploy an Istio VirtualService resource.",
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "hosts": {
-          "default": [],
-          "description": "Hostnames this VirtualService applies to. Can be a DNS name, wildcard (*.example.com), or short name resolved relative to the VS namespace.",
-          "items": {
-            "type": "string"
-          },
-          "title": "hosts",
-          "type": "array"
-        },
-        "gateways": {
-          "default": [],
-          "description": "Gateways this VirtualService is bound to. Use <namespace>/<name> format. Omit to apply rules to mesh-internal sidecar traffic only.",
-          "items": {
-            "type": "string"
-          },
-          "title": "gateways",
-          "type": "array"
-        },
-        "exportTo": {
-          "default": [],
-          "description": "Namespaces this VirtualService is exported to. '.' = same namespace only, '*' = all namespaces (default when omitted).",
-          "items": {
-            "type": "string"
-          },
-          "title": "exportTo",
-          "type": "array"
-        },
-        "http": {
-          "default": [],
-          "description": "Ordered HTTP route rules. First matching rule wins. Supports the full Istio HTTPRoute spec: match, route, rewrite, redirect, retries, timeout, fault, corsPolicy, headers, mirror, directResponse, delegate.",
-          "items": {
-            "required": [],
-            "type": "object"
-          },
-          "title": "http",
-          "type": "array"
-        },
-        "tls": {
-          "default": [],
-          "description": "Ordered TLS route rules for non-terminated TLS/HTTPS traffic (SNI-based routing).",
-          "items": {
-            "required": [],
-            "type": "object"
-          },
-          "title": "tls",
-          "type": "array"
-        },
-        "tcp": {
-          "default": [],
-          "description": "Ordered TCP route rules for opaque TCP traffic (non-HTTP, non-TLS ports).",
-          "items": {
-            "required": [],
-            "type": "object"
-          },
-          "title": "tcp",
-          "type": "array"
-        },
-        "routes": {
-          "default": {},
-          "description": "Multiple VirtualServices — use when you need more than one VS for this app. Each key produces a separate VS named <app>-<key>. When routes is set, the top-level hosts/gateways/http/tls/tcp fields are ignored.",
-          "additionalProperties": {
-            "properties": {
-              "hosts": {
-                "items": { "type": "string" },
-                "type": "array"
-              },
-              "gateways": {
-                "items": { "type": "string" },
-                "type": "array"
-              },
-              "exportTo": {
-                "items": { "type": "string" },
-                "type": "array"
-              },
-              "http": {
-                "items": { "type": "object", "required": [] },
-                "type": "array"
-              },
-              "tls": {
-                "items": { "type": "object", "required": [] },
-                "type": "array"
-              },
-              "tcp": {
-                "items": { "type": "object", "required": [] },
-                "type": "array"
-              }
-            },
-            "required": [],
-            "type": "object"
-          },
-          "title": "routes",
-          "type": "object"
-        }
-      },
-      "required": [],
-      "title": "virtualService",
       "type": "object"
     }
   },

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -656,6 +656,95 @@ ingress:
     #   hosts:
     #     - chart-example.local
 
+virtualService:
+  # -- (bool) Deploy an Istio VirtualService resource.
+  # Requires Istio to be installed in the cluster (networking.istio.io CRDs).
+  # Uses networking.istio.io/v1 if available, falls back to v1beta1.
+  # @section -- VirtualService Parameters
+  enabled: false
+  # -- (list) Hostnames this VirtualService applies to.
+  # Can be a DNS name, wildcard (*.example.com), or short name (resolved relative to the VS namespace).
+  # @section -- VirtualService Parameters
+  hosts: []
+  # - devops.example.com
+  # -- (list) Gateways this VirtualService is bound to.
+  # Use <namespace>/<name> format (e.g. istio-system/istio-gateway).
+  # Omit to apply rules to mesh-internal sidecar traffic only (mesh gateway).
+  # @section -- VirtualService Parameters
+  gateways: []
+  # - istio-system/istio-gateway
+  # -- (list, null) Namespaces this VirtualService is exported to.
+  # "." = same namespace only, "*" = all namespaces (default when omitted).
+  # @section -- VirtualService Parameters
+  exportTo: []
+  # - "."
+  # -- (list) Ordered HTTP route rules. First matching rule wins.
+  # Supports the full Istio HTTPRoute spec: match, route, rewrite, redirect,
+  # retries, timeout, fault, corsPolicy, headers, mirror, directResponse, delegate.
+  # @section -- VirtualService Parameters
+  http: []
+  # - match:
+  #     - uri:
+  #         prefix: /myapp
+  #   rewrite:
+  #     uri: /
+  #   route:
+  #     - destination:
+  #         host: myapp          # short name resolved to myapp.<namespace>.svc.cluster.local
+  #         port:
+  #           number: 8080
+  # -- (list) Ordered TLS route rules for non-terminated TLS/HTTPS (SNI-based routing).
+  # @section -- VirtualService Parameters
+  tls: []
+  # - match:
+  #     - port: 443
+  #       sniHosts:
+  #         - myapp.example.com
+  #   route:
+  #     - destination:
+  #         host: myapp
+  #         port:
+  #           number: 443
+  # -- (list) Ordered TCP route rules for opaque TCP traffic (non-HTTP, non-TLS ports).
+  # @section -- VirtualService Parameters
+  tcp: []
+  # - match:
+  #     - port: 5432
+  #   route:
+  #     - destination:
+  #         host: postgres
+  #         port:
+  #           number: 5432
+  # -- (object, null) Multiple VirtualServices — use when you need more than one VS for this app
+  # (e.g. external gateway + internal mesh-only rules). Each key produces a separate VS named
+  # <app>-<key>. Each entry supports the same fields as the top-level (hosts, gateways, exportTo, http, tls, tcp).
+  # When routes is set, the top-level hosts/gateways/http/tls/tcp fields are ignored.
+  # @section -- VirtualService Parameters
+  routes: {}
+  # external:
+  #   hosts:
+  #     - devops.example.com
+  #   gateways:
+  #     - istio-system/istio-gateway
+  #   http:
+  #     - match:
+  #         - uri:
+  #             prefix: /myapp
+  #       route:
+  #         - destination:
+  #             host: myapp
+  #             port:
+  #               number: 8080
+  # internal:
+  #   hosts:
+  #     - myapp.svc.cluster.local
+  #   http:
+  #     - route:
+  #         - destination:
+  #             host: myapp
+  #             port:
+  #               number: 8080
+
 httpRoute:
   # -- (bool) Enable HTTPRoute (Gateway API).
   # @section -- HTTPRoute Parameters


### PR DESCRIPTION
## Changes
- added `virtualService` section to `values.yaml` with full documentation (`hosts`, `gateways`, `exportTo`, `http`, `tls`, `tcp`, `routes`)
- added `virtualService` schema block to `values.schema.json`
- created `templates/virtualservice.yaml` : supports single-VS and multi-VS (`routes` map) modes; `http`/`tls`/`tcp` are `toYaml` pass-through.
- API version auto-detects `networking.istio.io/v1` vs `v1beta1`
- Added test to validate the new template.

## Remarks
- `virtualService.enabled` defaults to `false` to be fully backwards compatible
- when `routes` is omitted, a single VirtualService is rendered using the top-level `virtualService` fields; when `routes` is a map, one VirtualService is rendered per entry (name suffix skipped when key is `"default"`)